### PR TITLE
feat: add clock times, travel time between stops, and break management

### DIFF
--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -10,20 +10,23 @@ router = APIRouter()
 @router.post("/plan")
 async def create_plan(request: ItineraryRequest, db: Session = Depends(get_db)):
     places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
-    
+
     if not places:
         raise HTTPException(status_code=404, detail="No places found for given IDs")
 
-    optimized_plan = schedule_itinerary(places, request.total_minutes)
+    items = schedule_itinerary(
+        places,
+        request.total_minutes,
+        start_time=request.start_time,
+        break_duration_minutes=request.break_duration_minutes,
+        intensity=request.intensity,
+    )
 
+    scheduled = [i for i in items if i["type"] == "attraction"]
     return {
         "total_minutes": request.total_minutes,
-        "scheduled_places": [
-            {
-                "id": p.id, 
-                "name": p.name_en or p.name_pl, 
-                "duration": p.duration
-            } for p in optimized_plan
-        ],
-        "count": len(optimized_plan)
+        "start_time": request.start_time,
+        "intensity": request.intensity,
+        "items": items,
+        "count": len(scheduled),
     }

--- a/travel-guide/backend/app/schemas/itinerary.py
+++ b/travel-guide/backend/app/schemas/itinerary.py
@@ -4,3 +4,6 @@ from typing import List
 class ItineraryRequest(BaseModel):
     place_ids: List[int]
     total_minutes: int
+    intensity: str = "moderate"
+    start_time: str = "09:00"
+    break_duration_minutes: int = 30

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -1,16 +1,57 @@
-def schedule_itinerary(places, total_minutes):
+def _time_to_minutes(t: str) -> int:
+    h, m = map(int, t.split(":"))
+    return h * 60 + m
+
+def _minutes_to_time(total: int) -> str:
+    h = (total // 60) % 24
+    m = total % 60
+    return f"{h:02d}:{m:02d}"
+
+def _parse_duration(duration: str) -> int:
+    if not duration:
+        return 60
+    if "h" in duration and "min" in duration:
+        parts = duration.split("h")
+        return int(parts[0].strip()) * 60 + int(parts[1].replace("min", "").strip())
+    if "h" in duration:
+        return int(duration.split("h")[0].strip()) * 60
+    if "min" in duration:
+        return int(duration.split("min")[0].strip())
+    return 60
+
+def schedule_itinerary(places, total_minutes, start_time="09:00", break_duration_minutes=30, intensity="moderate"):
     plan = []
-    current_time = 0
-    
+    elapsed = 0
+    current = _time_to_minutes(start_time)
+    is_relaxed = intensity == "relaxed"
+
     for place in places:
-        duration_val = 60
-        if place.duration and 'h' in place.duration:
-            duration_val = int(place.duration.split('h')[0].strip()) * 60
-        elif place.duration and 'min' in place.duration:
-            duration_val = int(place.duration.split('min')[0].strip())
-            
-        if current_time + duration_val <= total_minutes:
-            plan.append(place)
-            current_time += duration_val
-            
+        duration_val = _parse_duration(place.duration)
+
+        if is_relaxed and plan:
+            current += break_duration_minutes
+            elapsed += break_duration_minutes
+            plan.append({
+                "type": "break",
+                "duration": break_duration_minutes,
+                "start_at": _minutes_to_time(current - break_duration_minutes),
+                "end_at": _minutes_to_time(current),
+            })
+
+        if elapsed + duration_val > total_minutes:
+            break
+
+        start_at = _minutes_to_time(current)
+        current += duration_val
+        elapsed += duration_val
+
+        plan.append({
+            "type": "attraction",
+            "id": place.id,
+            "name": place.name_en or place.name_pl,
+            "duration": place.duration,
+            "start_at": start_at,
+            "end_at": _minutes_to_time(current),
+        })
+
     return plan

--- a/travel-guide/docs/product-backlog.md
+++ b/travel-guide/docs/product-backlog.md
@@ -1,8 +1,8 @@
 # Product Backlog — Poznań Travel Guide
 
 > **Source:** GitHub Project board [`aymericz3/projects/2`](https://github.com/users/aymericz3/projects/2/views/1)
-> **Last updated:** 2026-05-16
-> **Last synced:** 2026-05-15
+> **Last updated:** 2026-05-28
+> **Last synced:** 2026-05-28
 > **Note:** This backlog is a living document and may evolve as the project progresses. It reflects the current state of identified work items, their status, and how they map to user stories and features.
 > **Related documents:** [Product Goal](product-goal.md), [Definition of Done](definition-of-done.md), [User Stories](user-stories.md), [Architecture](architecture.md)
 
@@ -58,6 +58,8 @@ The backlog is driven by the 7 user stories defined in [user-stories.md](user-st
 | [#3](https://github.com/aymericz3/erasmus-sds-2026/issues/3) | Create project initial structure (frontend / backend / database folders) | ✅ Completed | S1 · I1 |
 | [#34](https://github.com/aymericz3/erasmus-sds-2026/issues/34) | Create backend project structure (routes, services, models, config) | ✅ Completed | S1 · I1 |
 | [#33](https://github.com/aymericz3/erasmus-sds-2026/issues/33) | Connect backend to PostgreSQL | ✅ Completed | S1 · I2 |
+| [#48](https://github.com/aymericz3/erasmus-sds-2026/issues/48) | Connect frontend to backend | ✅ Completed | S1 · I3 |
+| [#49](https://github.com/aymericz3/erasmus-sds-2026/issues/49) | Fetch places from database | ✅ Completed | S1 · I3 |
 
 ---
 
@@ -98,7 +100,7 @@ The backlog is driven by the 7 user stories defined in [user-stories.md](user-st
 | [#19](https://github.com/aymericz3/erasmus-sds-2026/issues/19) | Show Plan Trip button once at least one attraction is selected | ✅ Completed | S1 · I2 |
 | [#13](https://github.com/aymericz3/erasmus-sds-2026/issues/13) | Implement category filtering logic (show only matching categories, multi-category support) | ✅ Completed | S1 · I2 |
 | [#14](https://github.com/aymericz3/erasmus-sds-2026/issues/14) | Show all attractions when no filter is selected (safe fallback) | ✅ Completed | S1 · I2 |
-| [#15](https://github.com/aymericz3/erasmus-sds-2026/issues/15) | Allow filter refinement directly from Results page (without returning home) | 📋 TODO | S1 · I4 |
+| [#15](https://github.com/aymericz3/erasmus-sds-2026/issues/15) | Allow filter refinement directly from Results page (without returning home) | ✅ Completed | S1 · I3 |
 
 ---
 
@@ -106,14 +108,15 @@ The backlog is driven by the 7 user stories defined in [user-stories.md](user-st
 
 | # | Title | Status | Sprint · Iter |
 |---|---|---|---|
-| [#22](https://github.com/aymericz3/erasmus-sds-2026/issues/22) | Define itinerary generation rules (fit within time, sort by priority/category/proximity) | 🔄 In Progress | S1 · I4 |
-| [#20](https://github.com/aymericz3/erasmus-sds-2026/issues/20) | Add trip duration input field (number of days or hours for a single-day trip) | 📋 TODO | S1 · I4 |
-| [#21](https://github.com/aymericz3/erasmus-sds-2026/issues/21) | Save duration input in state and pass it to the itinerary generator | 📋 TODO | S1 · I4 |
-| [#23](https://github.com/aymericz3/erasmus-sds-2026/issues/23) | Create backend endpoint or planner function (receives selected attractions + duration) | 📋 TODO | S1 · I4 |
-| [#24](https://github.com/aymericz3/erasmus-sds-2026/issues/24) | Implement basic planning algorithm (add attractions until time limit reached, return ordered list) | 📋 TODO | S1 · I4 |
-| [#25](https://github.com/aymericz3/erasmus-sds-2026/issues/25) | Create itinerary results page/section (display generated plan cleanly) | 📋 TODO | S1 · I4 |
-| [#26](https://github.com/aymericz3/erasmus-sds-2026/issues/26) | Handle insufficient time case (warn user when attractions cannot fit in available time) | 📋 TODO | S1 · I4 |
-| [#27](https://github.com/aymericz3/erasmus-sds-2026/issues/27) | Add regenerate button (re-run planner without re-entering data) | 🔄 In Progress | S1 · I4 |
+| [#22](https://github.com/aymericz3/erasmus-sds-2026/issues/22) | Define itinerary generation rules (fit within time, sort by priority/category/proximity) | ✅ Completed | S1 · I4 |
+| [#20](https://github.com/aymericz3/erasmus-sds-2026/issues/20) | Add trip duration input field (number of days or hours for a single-day trip) | ✅ Completed | S1 · I4 |
+| [#21](https://github.com/aymericz3/erasmus-sds-2026/issues/21) | Save duration input in state and pass it to the itinerary generator ✅ Completed | S1 · I4 |
+| [#23](https://github.com/aymericz3/erasmus-sds-2026/issues/23) | Create backend endpoint or planner function (receives selected attractions + duration) | ✅ Completed | S1 · I4 |
+| [#24](https://github.com/aymericz3/erasmus-sds-2026/issues/24) | Implement basic planning algorithm (add attractions until time limit reached, return ordered list) | ✅ Completed | S1 · I4 |
+| [#25](https://github.com/aymericz3/erasmus-sds-2026/issues/25) | Create itinerary results page/section (display generated plan cleanly) | ✅ Completed | S1 · I4 |
+| [#26](https://github.com/aymericz3/erasmus-sds-2026/issues/26) | Handle insufficient time case (warn user when attractions cannot fit in available time) | ✅ Completed | S1 · I4 |
+| [#27](https://github.com/aymericz3/erasmus-sds-2026/issues/27) | Add regenerate button (re-run planner without re-entering data) | ✅ Completed | S1 · I4 |
+| [#57](https://github.com/aymericz3/erasmus-sds-2026/issues/57) | Implement itinerary planner service and endpoint | ✅ Completed | S1 · I4 |
 
 ---
 
@@ -131,12 +134,12 @@ The backlog is driven by the 7 user stories defined in [user-stories.md](user-st
 
 | # | Title | Status | Sprint · Iter |
 |---|---|---|---|
-| [#51](https://github.com/aymericz3/erasmus-sds-2026/issues/51) | Define intensity level specifications (≥3 levels: attractions/day, walking distance, active hours, break frequency) | 📋 TODO | S1 · I4 |
-| [#52](https://github.com/aymericz3/erasmus-sds-2026/issues/52) | Create UI for selecting itinerary intensity (description per option, visual highlight, mobile-friendly) | 📋 TODO | S1 · I4 |
-| [#53](https://github.com/aymericz3/erasmus-sds-2026/issues/53) | Add intensity field to itinerary generation request (frontend → backend, default: Balanced) | 📋 TODO | S1 · I4 |
-| [#54](https://github.com/aymericz3/erasmus-sds-2026/issues/54) | Adapt itinerary generation based on intensity (Relaxed = fewer attractions, Explorer = more) | 📋 TODO | S1 · I4 |
-| [#55](https://github.com/aymericz3/erasmus-sds-2026/issues/55) | Insert free-time/downtime blocks in relaxed itineraries | 📋 TODO | S1 · I4 |
-| [#56](https://github.com/aymericz3/erasmus-sds-2026/issues/56) | Allow users to switch intensity after itinerary is generated (regenerate, optionally restore previous) | 📋 TODO | S1 · I4 |
+| [#51](https://github.com/aymericz3/erasmus-sds-2026/issues/51) | Define intensity level specifications (≥3 levels: attractions/day, walking distance, active hours, break frequency) | ✅ Completed | S1 · I4 |
+| [#52](https://github.com/aymericz3/erasmus-sds-2026/issues/52) | Create UI for selecting itinerary intensity (description per option, visual highlight, mobile-friendly) | ✅ Completed | S1 · I4 |
+| [#53](https://github.com/aymericz3/erasmus-sds-2026/issues/53) | Add intensity field to itinerary generation request (frontend → backend, default: Balanced) | ✅ Completed | S1 · I4 |
+| [#54](https://github.com/aymericz3/erasmus-sds-2026/issues/54) | Adapt itinerary generation based on intensity (Relaxed = fewer attractions, Explorer = more) | ✅ Completed | S1 · I4 |
+| [#55](https://github.com/aymericz3/erasmus-sds-2026/issues/55) | Insert free-time/downtime blocks in relaxed itineraries | ✅ Completed | S1 · I4 |
+| [#56](https://github.com/aymericz3/erasmus-sds-2026/issues/56) | Allow users to switch intensity after itinerary is generated (regenerate, optionally restore previous) | ✅ Completed | S1 · I4 |
 
 ---
 
@@ -144,8 +147,8 @@ The backlog is driven by the 7 user stories defined in [user-stories.md](user-st
 
 | # | Title | Status | Sprint · Iter |
 |---|---|---|---|
-| — | User can remove attractions from itinerary | 📌 Product Backlog | — |
-| — | User can reorder attractions in the itinerary | 📌 Product Backlog | — |
+| — | User can remove attractions from itinerary | ✅ Completed | S1 · I4 |
+| — | User can reorder attractions in the itinerary | ✅ Completed | S1 · I4 |
 
 ---
 
@@ -153,5 +156,87 @@ The backlog is driven by the 7 user stories defined in [user-stories.md](user-st
 
 | # | Title | Status | Sprint · Iter |
 |---|---|---|---|
-| — | User can see attractions on the map | 📌 Product Backlog | — |
-| — | User can see the route of the itinerary on the map | 📌 Product Backlog | — |
+| — | User can see attractions on the map | ✅ Completed | S1 · I4 |
+| — | User can see the route of the itinerary on the map | ✅ Completed | S1 · I4 |
+
+---
+
+### Feature 10 — Itinerary Scheduling & Time Management
+
+| # | Title | Status | Sprint · Iter |
+|---|---|---|---|
+| [#66](https://github.com/aymericz3/erasmus-sds-2026/issues/66) | Add configurable daily itinerary start time | 📋 TODO | S2 · I1 |
+| [#74](https://github.com/aymericz3/erasmus-sds-2026/issues/74) | Define attraction duration logic | 📋 TODO | S2 · I1 |
+| [#75](https://github.com/aymericz3/erasmus-sds-2026/issues/75) | Calculate itinerary schedule | 📋 TODO | S2 · I1 |
+| [#76](https://github.com/aymericz3/erasmus-sds-2026/issues/76) | Display attraction schedule in UI | 📋 TODO | S2 · I1 |
+| [#77](https://github.com/aymericz3/erasmus-sds-2026/issues/77) | Recalculate times after itinerary changes | 📋 TODO | S2 · I1 |
+| [#78](https://github.com/aymericz3/erasmus-sds-2026/issues/78) | Prevent scheduling conflicts | 📋 TODO | S2 · I1 |
+| [#103](https://github.com/aymericz3/erasmus-sds-2026/issues/103) | Design start time selection UI | 📋 TODO | S2 · I1 |
+| [#104](https://github.com/aymericz3/erasmus-sds-2026/issues/104) | Store daily start time | 📋 TODO | S2 · I1 |
+| [#105](https://github.com/aymericz3/erasmus-sds-2026/issues/105) | Update itinerary schedule | 📋 TODO | S2 · I1 |
+| [#106](https://github.com/aymericz3/erasmus-sds-2026/issues/106) | Validate realistic schedules | 📋 TODO | S2 · I1 |
+| [#67](https://github.com/aymericz3/erasmus-sds-2026/issues/67) | Implement itinerary recalculation engine | 📋 TODO | S2 · I2 |
+| [#68](https://github.com/aymericz3/erasmus-sds-2026/issues/68) | Validate itinerary feasibility | 📋 TODO | S2 · I2 |
+
+---
+
+### Feature 11 — Break Management
+
+| # | Title | Status | Sprint · Iter |
+|---|---|---|---|
+| [#63](https://github.com/aymericz3/erasmus-sds-2026/issues/63) | Implement break insertion into itinerary | 📋 TODO | S2 · I1 |
+| [#92](https://github.com/aymericz3/erasmus-sds-2026/issues/92) | Design break feature UI | 📋 TODO | S2 · I1 |
+| [#93](https://github.com/aymericz3/erasmus-sds-2026/issues/93) | Insert breaks into schedule | 📋 TODO | S2 · I1 |
+| [#94](https://github.com/aymericz3/erasmus-sds-2026/issues/94) | Edit and remove breaks | 📋 TODO | S2 · I2 |
+| [#95](https://github.com/aymericz3/erasmus-sds-2026/issues/95) | Validate schedule after breaks | 📋 TODO | S2 · I2 |
+
+---
+
+### Feature 12 — Transport & Distance
+
+| # | Title | Status | Sprint · Iter |
+|---|---|---|---|
+| [#62](https://github.com/aymericz3/erasmus-sds-2026/issues/62) | Add travel time estimation between itinerary locations | 📋 TODO | S2 · I1 |
+| [#64](https://github.com/aymericz3/erasmus-sds-2026/issues/64) | Add transportation preference selection | 📋 TODO | S2 · I1 |
+| [#65](https://github.com/aymericz3/erasmus-sds-2026/issues/65) | Display distance between itinerary locations | 📋 TODO | S2 · I1 |
+| [#89](https://github.com/aymericz3/erasmus-sds-2026/issues/89) | Calculate travel time | 📋 TODO | S2 · I1 |
+| [#90](https://github.com/aymericz3/erasmus-sds-2026/issues/90) | Display travel time in UI | 📋 TODO | S2 · I1 |
+| [#91](https://github.com/aymericz3/erasmus-sds-2026/issues/91) | Recalculate travel time | 📋 TODO | S2 · I2 |
+| [#96](https://github.com/aymericz3/erasmus-sds-2026/issues/96) | Design transport selection UI | 📋 TODO | S2 · I1 |
+| [#97](https://github.com/aymericz3/erasmus-sds-2026/issues/97) | Implement transport preference logic | 📋 TODO | S2 · I1 |
+| [#98](https://github.com/aymericz3/erasmus-sds-2026/issues/98) | Update itinerary calculations | 📋 TODO | S2 · I2 |
+| [#99](https://github.com/aymericz3/erasmus-sds-2026/issues/99) | Save transport preference | 📋 TODO | S2 · I2 |
+| [#100](https://github.com/aymericz3/erasmus-sds-2026/issues/100) | Calculate attraction distances | 📋 TODO | S2 · I1 |
+| [#101](https://github.com/aymericz3/erasmus-sds-2026/issues/101) | Display distances in UI | 📋 TODO | S2 · I2 |
+| [#102](https://github.com/aymericz3/erasmus-sds-2026/issues/102) | Update distances dynamically | 📋 TODO | S2 · I2 |
+
+---
+
+### Feature 13 — External API Integration
+
+| # | Title | Status | Sprint · Iter |
+|---|---|---|---|
+| [#61](https://github.com/aymericz3/erasmus-sds-2026/issues/61) | Integrate ZPM API | 📋 TODO | S2 · I2 |
+| [#84](https://github.com/aymericz3/erasmus-sds-2026/issues/84) | Select attractions API | 📋 TODO | S2 · I2 |
+| [#85](https://github.com/aymericz3/erasmus-sds-2026/issues/85) | Integrate API connection | 📋 TODO | S2 · I2 |
+| [#86](https://github.com/aymericz3/erasmus-sds-2026/issues/86) | Fetch attraction details | 📋 TODO | S2 · I2 |
+| [#87](https://github.com/aymericz3/erasmus-sds-2026/issues/87) | Handle API failures | 📋 TODO | S2 · I2 |
+| [#88](https://github.com/aymericz3/erasmus-sds-2026/issues/88) | Integrate routing service | 📋 TODO | S2 · I2 |
+
+---
+
+### Feature 14 — Personalized Itinerary Generation
+
+| # | Title | Status | Sprint · Iter |
+|---|---|---|---|
+| [#60](https://github.com/aymericz3/erasmus-sds-2026/issues/60) | Implement personalized itinerary generation | 📋 TODO | S2 · I2 |
+| [#69](https://github.com/aymericz3/erasmus-sds-2026/issues/69) | Create preference data model | 📋 TODO | S2 · I1 |
+| [#70](https://github.com/aymericz3/erasmus-sds-2026/issues/70) | Create preference settings UI | 📋 TODO | S2 · I2 |
+| [#71](https://github.com/aymericz3/erasmus-sds-2026/issues/71) | Save user preferences | 📋 TODO | S2 · I2 |
+| [#72](https://github.com/aymericz3/erasmus-sds-2026/issues/72) | Load saved preferences | 📋 TODO | S2 · I2 |
+| [#73](https://github.com/aymericz3/erasmus-sds-2026/issues/73) | Edit saved preferences | 📋 TODO | S2 · I2 |
+| [#79](https://github.com/aymericz3/erasmus-sds-2026/issues/79) | Define personalization factors | 📋 TODO | S2 · I1 |
+| [#80](https://github.com/aymericz3/erasmus-sds-2026/issues/80) | Collect user preferences | 📋 TODO | S2 · I2 |
+| [#81](https://github.com/aymericz3/erasmus-sds-2026/issues/81) | Implement recommendation weighting logic | 📋 TODO | S2 · I2 |
+| [#82](https://github.com/aymericz3/erasmus-sds-2026/issues/82) | Generate personalized itinerary | 📋 TODO | S2 · I2 |
+| [#83](https://github.com/aymericz3/erasmus-sds-2026/issues/83) | Test personalization quality | 📋 TODO | S2 · I3 |

--- a/travel-guide/frontend/src/App.jsx
+++ b/travel-guide/frontend/src/App.jsx
@@ -2,10 +2,20 @@ import { useState, useEffect } from "react";
 import "leaflet/dist/leaflet.css";
 
 import { CATEGORIES } from "./constants";
-import { parseDurationToMinutes, formatMinutes, buildDailyItinerary } from "./utils";
+import {
+  parseDurationToMinutes, formatMinutes,
+  buildDailyItinerary, computeDayItems, computeTravelMinutes,
+} from "./utils";
 import HomePage from "./pages/HomePage";
 import ResultsPage from "./pages/ResultsPage";
 import ItineraryPage from "./pages/ItineraryPage";
+
+function totalFromItems(items) {
+  return items.reduce(
+    (s, item) => s + (item.type === "attraction" ? parseDurationToMinutes(item.duration) : item.duration),
+    0
+  );
+}
 
 function App() {
   const [selectedCategories, setSelectedCategories] = useState([]);
@@ -15,6 +25,7 @@ function App() {
   const [arrivalDate, setArrivalDate] = useState("");
   const [numDays, setNumDays] = useState(1);
   const [intensity, setIntensity] = useState("moderate");
+  const [startTime, setStartTime] = useState("09:00");
   const [itineraryDays, setItineraryDays] = useState(null);
 
   useEffect(() => {
@@ -58,13 +69,13 @@ function App() {
     : null;
 
   const generateItinerary = () => {
-    setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, intensity));
+    setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, intensity, startTime));
     setPage("itinerary");
   };
 
   const changeIntensity = (newIntensity) => {
     setIntensity(newIntensity);
-    setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, newIntensity));
+    setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, newIntensity, startTime));
   };
 
   const moveAttractionInDay = (dayIndex, attractionIndex, dir) => {
@@ -75,9 +86,15 @@ function App() {
       const newAttractions = [...day.attractions];
       [newAttractions[attractionIndex], newAttractions[targetIndex]] =
         [newAttractions[targetIndex], newAttractions[attractionIndex]];
+      const newTravelMinutes = computeTravelMinutes(newAttractions);
+      const newItems = computeDayItems(newAttractions, newTravelMinutes, day.breakDurations, startTime);
       return {
         ...prev,
-        days: prev.days.map((d, i) => (i === dayIndex ? { ...d, attractions: newAttractions } : d)),
+        days: prev.days.map((d, i) =>
+          i === dayIndex
+            ? { ...d, attractions: newAttractions, travelMinutes: newTravelMinutes, items: newItems, totalMinutes: totalFromItems(newItems) }
+            : d
+        ),
       };
     });
   };
@@ -87,14 +104,73 @@ function App() {
     setItineraryDays((prev) => {
       if (!prev) return prev;
       const newDays = prev.days.map((day) => {
+        const attrIndex = day.attractions.findIndex((a) => a.id === attractionId);
+        if (attrIndex === -1) return day;
         const newAttractions = day.attractions.filter((a) => a.id !== attractionId);
-        return {
-          ...day,
-          attractions: newAttractions,
-          totalMinutes: newAttractions.reduce((s, a) => s + parseDurationToMinutes(a.duration), 0),
-        };
+        const newBreakDurations = [...day.breakDurations];
+        if (attrIndex === 0) {
+          newBreakDurations.splice(0, 1);
+        } else if (attrIndex === day.attractions.length - 1) {
+          newBreakDurations.splice(attrIndex - 1, 1);
+        } else {
+          newBreakDurations.splice(attrIndex - 1, 2, null);
+        }
+        const newTravelMinutes = computeTravelMinutes(newAttractions);
+        const newItems = computeDayItems(newAttractions, newTravelMinutes, newBreakDurations, startTime);
+        return { ...day, attractions: newAttractions, travelMinutes: newTravelMinutes, breakDurations: newBreakDurations, items: newItems, totalMinutes: totalFromItems(newItems) };
       });
       return { days: newDays, overflow: prev.overflow.filter((a) => a.id !== attractionId) };
+    });
+  };
+
+  const addBreak = (dayIndex, gapIndex) => {
+    setItineraryDays((prev) => {
+      const day = prev.days[dayIndex];
+      const newBreakDurations = [...day.breakDurations];
+      newBreakDurations[gapIndex] = 30;
+      const newItems = computeDayItems(day.attractions, day.travelMinutes, newBreakDurations, startTime);
+      return {
+        ...prev,
+        days: prev.days.map((d, i) =>
+          i === dayIndex
+            ? { ...d, breakDurations: newBreakDurations, items: newItems, totalMinutes: totalFromItems(newItems) }
+            : d
+        ),
+      };
+    });
+  };
+
+  const removeBreak = (dayIndex, gapIndex) => {
+    setItineraryDays((prev) => {
+      const day = prev.days[dayIndex];
+      const newBreakDurations = [...day.breakDurations];
+      newBreakDurations[gapIndex] = null;
+      const newItems = computeDayItems(day.attractions, day.travelMinutes, newBreakDurations, startTime);
+      return {
+        ...prev,
+        days: prev.days.map((d, i) =>
+          i === dayIndex
+            ? { ...d, breakDurations: newBreakDurations, items: newItems, totalMinutes: totalFromItems(newItems) }
+            : d
+        ),
+      };
+    });
+  };
+
+  const changeBreakDuration = (dayIndex, gapIndex, delta) => {
+    setItineraryDays((prev) => {
+      const day = prev.days[dayIndex];
+      const newBreakDurations = [...day.breakDurations];
+      newBreakDurations[gapIndex] = Math.max(15, Math.min(120, (newBreakDurations[gapIndex] ?? 30) + delta));
+      const newItems = computeDayItems(day.attractions, day.travelMinutes, newBreakDurations, startTime);
+      return {
+        ...prev,
+        days: prev.days.map((d, i) =>
+          i === dayIndex
+            ? { ...d, breakDurations: newBreakDurations, items: newItems, totalMinutes: totalFromItems(newItems) }
+            : d
+        ),
+      };
     });
   };
 
@@ -106,11 +182,13 @@ function App() {
           numDays={numDays}
           departureDate={departureDate}
           intensity={intensity}
+          startTime={startTime}
           selectedCategories={selectedCategories}
           allCategoriesSelected={allCategoriesSelected}
           onArrivalDateChange={setArrivalDate}
           onNumDaysChange={setNumDays}
           onIntensityChange={setIntensity}
+          onStartTimeChange={setStartTime}
           onToggleCategory={toggleCategory}
           onToggleAllCategories={toggleAllCategories}
           onExplore={() => setPage("results")}
@@ -145,6 +223,9 @@ function App() {
           onRegenerate={generateItinerary}
           onMoveAttraction={moveAttractionInDay}
           onRemoveAttraction={removeFromItinerary}
+          onAddBreak={addBreak}
+          onRemoveBreak={removeBreak}
+          onChangeBreakDuration={changeBreakDuration}
         />
       )}
     </div>

--- a/travel-guide/frontend/src/index.css
+++ b/travel-guide/frontend/src/index.css
@@ -236,7 +236,9 @@ h1 {
 
 .itinerary-item {
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  gap: 8px;
   padding: 22px;
   border: 1px solid #ddd;
   border-radius: 16px;
@@ -604,19 +606,152 @@ h1 {
   white-space: nowrap;
 }
 
-/* Overflow block */
-/* Downtime / break slots (#55) */
-.downtime-slot {
+/* Time range label on itinerary items */
+.item-time-range {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6366f1;
+  font-variant-numeric: tabular-nums;
+  padding: 2px 10px 2px 0;
+  white-space: nowrap;
+  min-width: 130px;
+}
+
+/* Travel time connector between stops */
+.travel-slot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 24px;
+  background: #f4f4f8;
+  border-bottom: 1px solid #ebebf5;
+  gap: 12px;
+}
+
+.travel-slot-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #888;
+  font-size: 13px;
+}
+
+.travel-icon {
+  font-size: 14px;
+}
+
+.travel-label {
+  font-weight: 500;
+}
+
+.travel-time {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: #6366f1;
+  margin-left: 6px;
+}
+
+.add-break-btn {
+  font-size: 12px;
+  padding: 3px 10px;
+  border-radius: 12px;
+  border: 1px dashed #b0b0c8;
+  background: transparent;
+  color: #888;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.add-break-btn:hover {
+  background: #ebebf5;
+  color: #444;
+}
+
+/* Break slots */
+.break-slot {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 10px 24px;
-  background: #f7f7f8;
-  border-bottom: 1px solid #eee;
-  font-size: 14px;
+  background: #f7f7fb;
+  border-bottom: 1px solid #ebebf5;
+  gap: 12px;
+}
+
+.break-slot-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   color: #6b6b80;
+  font-size: 14px;
   font-style: italic;
 }
+
+.break-time {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6366f1;
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.break-icon {
+  white-space: nowrap;
+}
+
+.break-slot-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.break-adj-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid #d1d1e0;
+  background: white;
+  color: #444;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  transition: background 0.15s;
+}
+
+.break-adj-btn:hover:not(:disabled) {
+  background: #ebebf5;
+}
+
+.break-adj-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.break-duration {
+  font-size: 14px;
+  color: #6b6b80;
+  min-width: 52px;
+  text-align: center;
+}
+
+/* Day over-budget warning (#95) */
+.day-warning {
+  margin: 0 24px 0;
+  padding: 10px 14px;
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #9a3412;
+}
+
+/* Overflow block */
 
 .overflow-block {
   margin-top: 16px;

--- a/travel-guide/frontend/src/pages/HomePage.jsx
+++ b/travel-guide/frontend/src/pages/HomePage.jsx
@@ -2,8 +2,8 @@ import { CATEGORIES, INTENSITY_OPTIONS } from "../constants";
 
 export default function HomePage({
   arrivalDate, numDays, departureDate,
-  intensity, selectedCategories, allCategoriesSelected,
-  onArrivalDateChange, onNumDaysChange, onIntensityChange,
+  intensity, startTime, selectedCategories, allCategoriesSelected,
+  onArrivalDateChange, onNumDaysChange, onIntensityChange, onStartTimeChange,
   onToggleCategory, onToggleAllCategories, onExplore,
 }) {
   return (
@@ -30,9 +30,16 @@ export default function HomePage({
               onChange={(e) => onNumDaysChange(Math.max(1, parseInt(e.target.value) || 1))}
             />
           </div>
+          <div className="stay-field">
+            <label htmlFor="start-time">Daily start time</label>
+            <input
+              id="start-time" type="time" value={startTime}
+              onChange={(e) => onStartTimeChange(e.target.value)}
+            />
+          </div>
           {arrivalDate && (
             <div className="stay-summary">
-              {arrivalDate} → {departureDate} · {numDays} {numDays === 1 ? "day" : "days"}
+              {arrivalDate} → {departureDate} · {numDays} {numDays === 1 ? "day" : "days"} · starts at {startTime}
             </div>
           )}
         </div>

--- a/travel-guide/frontend/src/pages/ItineraryPage.jsx
+++ b/travel-guide/frontend/src/pages/ItineraryPage.jsx
@@ -7,7 +7,10 @@ export default function ItineraryPage({
   arrivalDate, numDays, departureDate,
   onBack, onChangeIntensity, onRegenerate,
   onMoveAttraction, onRemoveAttraction,
+  onAddBreak, onRemoveBreak, onChangeBreakDuration,
 }) {
+  const intensityConfig = INTENSITY_OPTIONS.find((o) => o.key === intensity);
+
   return (
     <section className="itinerary">
       <button className="back" onClick={onBack}>← Back to Attractions</button>
@@ -45,69 +48,137 @@ export default function ItineraryPage({
         <ItineraryMap days={days} />
       </div>
 
-      {days.map((day, dayIndex) => (
-        <div key={dayIndex} className="day-block">
-          <div className="day-header">
-            <h2>
-              Day {dayIndex + 1}
-              {arrivalDate && (
-                <span className="day-date"> — {formatDayDate(arrivalDate, dayIndex)}</span>
-              )}
-            </h2>
-            <span className="day-duration">{formatMinutes(day.totalMinutes)}</span>
-          </div>
+      {days.map((day, dayIndex) => {
+        let attrCounter = 0;
 
-          {day.attractions.length === 0 ? (
-            <p className="day-empty">No attractions planned for this day.</p>
-          ) : (
-            <div className="itinerary-list">
-              {day.attractions.flatMap((attraction, i) => {
-                const isLast = i === day.attractions.length - 1;
-                const item = (
-                  <div key={attraction.id} className="itinerary-item">
-                    <div className="itinerary-item-info">
-                      <span className="itinerary-item-number">{i + 1}</span>
-                      <div>
-                        <strong>{attraction.name_en || attraction.name_pl}</strong>
-                        <span className="itinerary-item-category">{attraction.category}</span>
-                      </div>
-                    </div>
-                    <div className="itinerary-item-actions">
-                      <span className="itinerary-item-duration">{attraction.duration}</span>
-                      <div className="reorder-btns">
-                        <button
-                          className="reorder-btn"
-                          onClick={() => onMoveAttraction(dayIndex, i, "up")}
-                          disabled={i === 0}
-                          title="Move up"
-                        >↑</button>
-                        <button
-                          className="reorder-btn"
-                          onClick={() => onMoveAttraction(dayIndex, i, "down")}
-                          disabled={i === day.attractions.length - 1}
-                          title="Move down"
-                        >↓</button>
-                      </div>
-                      <button
-                        className="remove-btn"
-                        onClick={() => onRemoveAttraction(attraction.id)}
-                        title="Remove"
-                      >×</button>
-                    </div>
-                  </div>
-                );
-                const breakSlot = intensity === "relaxed" && !isLast ? (
-                  <div key={`break-${attraction.id}`} className="downtime-slot">
-                    <span>☕ Break</span>
-                    <span>30 min</span>
-                  </div>
-                ) : null;
-                return [item, breakSlot].filter(Boolean);
-              })}
+        return (
+          <div key={dayIndex} className="day-block">
+            <div className="day-header">
+              <h2>
+                Day {dayIndex + 1}
+                {arrivalDate && (
+                  <span className="day-date"> — {formatDayDate(arrivalDate, dayIndex)}</span>
+                )}
+              </h2>
+              <span className="day-duration">{formatMinutes(day.totalMinutes)}</span>
             </div>
-          )}
-        </div>
-      ))}
+
+            {day.totalMinutes > intensityConfig.maxMinutesPerDay && (
+              <div className="day-warning">
+                ⚠ This day is {formatMinutes(day.totalMinutes - intensityConfig.maxMinutesPerDay)} over
+                your <strong>{intensityConfig.label}</strong> limit — shorten a break or remove an attraction.
+              </div>
+            )}
+
+            {day.items.length === 0 ? (
+              <p className="day-empty">No attractions planned for this day.</p>
+            ) : (
+              <div className="itinerary-list">
+                {day.items.map((item) => {
+                  if (item.type === "travel") {
+                    const hasBreak = day.breakDurations[item.gapIndex] != null;
+                    return (
+                      <div key={item.id} className="travel-slot">
+                        <div className="travel-slot-info">
+                          {item.duration > 0 && (
+                            <>
+                              <span className="travel-icon">🚶</span>
+                              <span className="travel-label">{item.duration} min walk</span>
+                              {item.start_at && (
+                                <span className="travel-time">{item.start_at} → {item.end_at}</span>
+                              )}
+                            </>
+                          )}
+                        </div>
+                        {!hasBreak && (
+                          <button
+                            className="add-break-btn"
+                            onClick={() => onAddBreak(dayIndex, item.gapIndex)}
+                          >
+                            + Break
+                          </button>
+                        )}
+                      </div>
+                    );
+                  }
+
+                  if (item.type === "break") {
+                    return (
+                      <div key={item.id} className="break-slot">
+                        <div className="break-slot-label">
+                          {item.start_at && (
+                            <span className="break-time">{item.start_at} → {item.end_at}</span>
+                          )}
+                          <span className="break-icon">☕ Break</span>
+                        </div>
+                        <div className="break-slot-controls">
+                          <button
+                            className="break-adj-btn"
+                            onClick={() => onChangeBreakDuration(dayIndex, item.gapIndex, -15)}
+                            disabled={item.duration <= 15}
+                          >−</button>
+                          <span className="break-duration">{item.duration} min</span>
+                          <button
+                            className="break-adj-btn"
+                            onClick={() => onChangeBreakDuration(dayIndex, item.gapIndex, +15)}
+                            disabled={item.duration >= 120}
+                          >+</button>
+                          <button
+                            className="remove-btn"
+                            onClick={() => onRemoveBreak(dayIndex, item.gapIndex)}
+                            title="Remove break"
+                          >×</button>
+                        </div>
+                      </div>
+                    );
+                  }
+
+                  const currentAttrIndex = attrCounter++;
+                  const isFirstAttr = currentAttrIndex === 0;
+                  const isLastAttr = currentAttrIndex === day.attractions.length - 1;
+
+                  return (
+                    <div key={item.id} className="itinerary-item">
+                      {item.start_at && (
+                        <span className="item-time-range">{item.start_at} → {item.end_at}</span>
+                      )}
+                      <div className="itinerary-item-info">
+                        <span className="itinerary-item-number">{currentAttrIndex + 1}</span>
+                        <div>
+                          <strong>{item.name_en || item.name_pl}</strong>
+                          <span className="itinerary-item-category">{item.category}</span>
+                        </div>
+                      </div>
+                      <div className="itinerary-item-actions">
+                        <span className="itinerary-item-duration">{item.duration}</span>
+                        <div className="reorder-btns">
+                          <button
+                            className="reorder-btn"
+                            onClick={() => onMoveAttraction(dayIndex, currentAttrIndex, "up")}
+                            disabled={isFirstAttr}
+                            title="Move up"
+                          >↑</button>
+                          <button
+                            className="reorder-btn"
+                            onClick={() => onMoveAttraction(dayIndex, currentAttrIndex, "down")}
+                            disabled={isLastAttr}
+                            title="Move down"
+                          >↓</button>
+                        </div>
+                        <button
+                          className="remove-btn"
+                          onClick={() => onRemoveAttraction(item.id)}
+                          title="Remove"
+                        >×</button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
 
       {overflow.length > 0 && (
         <div className="overflow-block">

--- a/travel-guide/frontend/src/utils.js
+++ b/travel-guide/frontend/src/utils.js
@@ -27,27 +27,117 @@ export function formatDayDate(arrivalDate, dayIndex) {
   return date.toLocaleDateString("en-GB", { weekday: "long", day: "numeric", month: "long" });
 }
 
-export function buildDailyItinerary(attractions, numDays, intensityKey) {
+function timeToMinutes(timeStr) {
+  const [h, m] = timeStr.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function minutesToTime(total) {
+  const h = Math.floor(total / 60) % 24;
+  const m = total % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+function recalculateItemTimes(items, startTimeStr) {
+  let current = timeToMinutes(startTimeStr);
+  return items.map((item) => {
+    const duration = item.type === "attraction"
+      ? parseDurationToMinutes(item.duration)
+      : item.duration;
+    const start_at = minutesToTime(current);
+    current += duration;
+    const end_at = minutesToTime(current);
+    return { ...item, start_at, end_at };
+  });
+}
+
+// Haversine distance → walking minutes, rounded UP to nearest 5
+export function haversineMinutes(a1, a2, speedKmh = 5) {
+  if (!a1?.latitude || !a1?.longitude || !a2?.latitude || !a2?.longitude) return 0;
+  const R = 6371;
+  const lat1 = a1.latitude * Math.PI / 180;
+  const lat2 = a2.latitude * Math.PI / 180;
+  const dLat = (a2.latitude - a1.latitude) * Math.PI / 180;
+  const dLon = (a2.longitude - a1.longitude) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  const distKm = R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const raw = (distKm / speedKmh) * 60;
+  return Math.ceil(raw / 5) * 5;
+}
+
+export function computeTravelMinutes(attractions) {
+  return attractions.slice(0, -1).map((a, i) => haversineMinutes(a, attractions[i + 1]));
+}
+
+// Builds the flat items list for one day, inserting travel and break rows between attractions.
+// travelMinutes[i] = walk time between attraction[i] and attraction[i+1]
+// breakDurations[i] = break duration at gap i, or null if no break
+export function computeDayItems(attractions, travelMinutes, breakDurations, startTime) {
+  const rawItems = [];
+  attractions.forEach((attr, i) => {
+    rawItems.push({ type: "attraction", ...attr });
+    if (i < attractions.length - 1) {
+      const travel = travelMinutes[i] ?? 0;
+      rawItems.push({ type: "travel", id: `travel-${attr.id}`, duration: travel, gapIndex: i });
+      const breakDur = breakDurations[i];
+      if (breakDur != null) {
+        rawItems.push({ type: "break", id: `break-${attr.id}`, duration: breakDur, gapIndex: i });
+      }
+    }
+  });
+  return recalculateItemTimes(rawItems, startTime);
+}
+
+export function buildDailyItinerary(attractions, numDays, intensityKey, startTime = "09:00", breakDurationMinutes = 30) {
   const config = INTENSITY_OPTIONS.find((o) => o.key === intensityKey);
   const maxMinPerDay = config.maxMinutesPerDay;
-  const days = Array.from({ length: numDays }, () => ({ attractions: [], totalMinutes: 0 }));
+  const isRelaxed = intensityKey === "relaxed";
+
+  const days = Array.from({ length: numDays }, () => ({
+    attractions: [],
+    travelMinutes: [],
+    breakDurations: [],
+    items: [],
+    totalMinutes: 0,
+  }));
   const overflow = [];
 
   for (const attraction of attractions) {
     const duration = parseDurationToMinutes(attraction.duration);
-    const dayIndex = days.findIndex((day) =>
-      day.totalMinutes + duration <= maxMinPerDay &&
-      (config.maxAttractionsPerDay === null ||
-        day.attractions.length < config.maxAttractionsPerDay)
-    );
+
+    const dayIndex = days.findIndex((day) => {
+      const last = day.attractions[day.attractions.length - 1];
+      const travel = last ? haversineMinutes(last, attraction) : 0;
+      const breakOverhead = isRelaxed && day.attractions.length > 0 ? breakDurationMinutes : 0;
+      return (
+        day.totalMinutes + travel + breakOverhead + duration <= maxMinPerDay &&
+        (config.maxAttractionsPerDay === null || day.attractions.length < config.maxAttractionsPerDay)
+      );
+    });
+
     if (dayIndex !== -1) {
-      days[dayIndex].attractions.push(attraction);
-      days[dayIndex].totalMinutes += duration;
+      const day = days[dayIndex];
+      if (day.attractions.length > 0) {
+        const last = day.attractions[day.attractions.length - 1];
+        const travel = haversineMinutes(last, attraction);
+        day.travelMinutes.push(travel);
+        day.totalMinutes += travel;
+        day.breakDurations.push(isRelaxed ? breakDurationMinutes : null);
+        if (isRelaxed) day.totalMinutes += breakDurationMinutes;
+      }
+      day.attractions.push(attraction);
+      day.totalMinutes += duration;
     } else {
       overflow.push(attraction);
     }
   }
-  return { days, overflow };
+
+  const daysWithItems = days.map((day) => ({
+    ...day,
+    items: computeDayItems(day.attractions, day.travelMinutes, day.breakDurations, startTime),
+  }));
+
+  return { days: daysWithItems, overflow };
 }
 
 export function createMarkerIcon(color, label) {


### PR DESCRIPTION
- Itinerary now shows start/end times per stop (e.g. 09:00 → 10:30)
- Walking time between consecutive stops computed via Haversine, rounded up to nearest 5 min (e.g. 11 min → 15 min)
- Breaks can be added, removed, and adjusted in all intensity modes
- Travel connector row shows a '+ Break' button when no break exists
- Day warning banner appears when breaks push the day over its limit
- Home page has a 'Daily start time' input (default 09:00)
- Backend /itinerary/plan updated to accept start_time, intensity, and break_duration_minutes, returning items with start_at/end_at
- Product backlog updated: mark F8, F9, #15, #55 as completed