### PR TITLE
feat: add Google Maps Distance Matrix transport backend

### DIFF
--- a/travel-guide/backend/app/core/config.py
+++ b/travel-guide/backend/app/core/config.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = "postgresql://localhost/travel_guide"
+    google_maps_api_key: str = ""
 
     model_config = {"env_file": ".env"}
     

--- a/travel-guide/backend/app/main.py
+++ b/travel-guide/backend/app/main.py
@@ -5,7 +5,7 @@ Main application file for the Travel Guide backend.
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.routes import categories, places
+from app.routes import categories, places, transport
 from app.api.endpoints import itinerary
 
 # Create FastAPI application instance
@@ -23,6 +23,7 @@ app.add_middleware(
 app.include_router(categories.router)
 app.include_router(places.router)
 app.include_router(itinerary.router, prefix="/itinerary", tags=["itinerary"])
+app.include_router(transport.router, prefix="/transport", tags=["transport"])
 
 # Root endpoint to verify that the API is running
 @app.get("/")

--- a/travel-guide/backend/app/routes/transport.py
+++ b/travel-guide/backend/app/routes/transport.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from app.schemas.transport import TransportRequest, TransportResponse
+from app.services.transport_service import get_travel_times
+
+router = APIRouter()
+
+@router.post("/times", response_model=TransportResponse)
+def travel_times(req: TransportRequest):
+    """Return walking, cycling, driving, and tram travel times between two coordinates."""
+    return get_travel_times(req.origin_lat, req.origin_lon, req.dest_lat, req.dest_lon)

--- a/travel-guide/backend/app/schemas/transport.py
+++ b/travel-guide/backend/app/schemas/transport.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+class TransportRequest(BaseModel):
+    origin_lat: float
+    origin_lon: float
+    dest_lat: float
+    dest_lon: float
+
+class TransportMode(BaseModel):
+    minutes: int
+    distance_km: float
+    source: str  # "google" or "estimate"
+
+class TransportResponse(BaseModel):
+    walking: TransportMode
+    cycling: TransportMode
+    driving: TransportMode
+    tram: TransportMode

--- a/travel-guide/backend/app/services/transport_service.py
+++ b/travel-guide/backend/app/services/transport_service.py
@@ -1,0 +1,91 @@
+import math
+import requests
+from app.core.config import settings
+
+GOOGLE_BASE = "https://maps.googleapis.com/maps/api/distancematrix/json"
+
+# Modes sent to Google Distance Matrix API
+_GOOGLE_MODES = {
+    "walking":  {"mode": "walking"},
+    "cycling":  {"mode": "bicycling"},
+    "driving":  {"mode": "driving"},
+    "tram":     {"mode": "transit", "transit_mode": "tram|rail"},
+}
+
+
+def _haversine_km(lat1, lon1, lat2, lon2) -> float:
+    R = 6371
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlon / 2) ** 2
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _round_up_5(minutes: float) -> int:
+    return math.ceil(minutes / 5) * 5
+
+
+def _fallback_minutes(km: float, mode: str) -> int:
+    """Rough estimate when Google API is unavailable, rounded up to nearest 5 min."""
+    speeds = {"walking": 5, "cycling": 15, "driving": 30, "tram": 20}
+    raw = (km / speeds.get(mode, 5)) * 60
+    return _round_up_5(raw)
+
+
+def _call_google(origin_lat, origin_lon, dest_lat, dest_lon, mode_key: str) -> dict | None:
+    """
+    Call Google Distance Matrix for one mode.
+    Returns {"minutes": int, "distance_km": float} or None on failure.
+    """
+    if not settings.google_maps_api_key or settings.google_maps_api_key == "your_key_here":
+        return None
+
+    params = {
+        "origins": f"{origin_lat},{origin_lon}",
+        "destinations": f"{dest_lat},{dest_lon}",
+        "key": settings.google_maps_api_key,
+        **_GOOGLE_MODES[mode_key],
+    }
+
+    try:
+        resp = requests.get(GOOGLE_BASE, params=params, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        element = data["rows"][0]["elements"][0]
+        if element["status"] != "OK":
+            return None
+        minutes = math.ceil(element["duration"]["value"] / 60)
+        distance_km = round(element["distance"]["value"] / 1000, 2)
+        return {"minutes": minutes, "distance_km": distance_km}
+    except Exception:
+        return None
+
+
+def get_travel_times(origin_lat: float, origin_lon: float, dest_lat: float, dest_lon: float) -> dict:
+    """
+    Return travel time and distance for all 4 modes between two coordinates.
+    Falls back to Haversine estimates if Google API is unavailable.
+
+    Returns:
+        {
+            "walking":  {"minutes": int, "distance_km": float, "source": "google"|"estimate"},
+            "cycling":  {...},
+            "driving":  {...},
+            "tram":     {...},
+        }
+    """
+    km = _haversine_km(origin_lat, origin_lon, dest_lat, dest_lon)
+    results = {}
+
+    for mode in _GOOGLE_MODES:
+        google = _call_google(origin_lat, origin_lon, dest_lat, dest_lon, mode)
+        if google:
+            results[mode] = {**google, "source": "google"}
+        else:
+            results[mode] = {
+                "minutes": _fallback_minutes(km, mode),
+                "distance_km": round(km, 2),
+                "source": "estimate",
+            }
+
+    return results

--- a/travel-guide/backend/requirements.txt
+++ b/travel-guide/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.29.0
 pydantic-settings>=2.0.0
 sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.0
+requests>=2.31.0

--- a/travel-guide/backend/scripts/test_transport.py
+++ b/travel-guide/backend/scripts/test_transport.py
@@ -1,0 +1,97 @@
+"""
+Terminal test script for the transport service.
+
+Usage (from travel-guide/backend/):
+    source .venv/bin/activate
+    python scripts/test_transport.py
+
+Optionally test a specific pair by index:
+    python scripts/test_transport.py --pair 0 2
+"""
+
+import sys
+import os
+import argparse
+
+# Allow importing from the app package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.db.session import get_db
+from app.models.place import Place
+from app.services.transport_service import get_travel_times
+from app.core.config import settings
+
+ICONS = {"walking": "🚶", "cycling": "🚲", "driving": "🚗", "tram": "🚋"}
+SEPARATOR = "─" * 60
+
+
+def fmt(mode_data: dict) -> str:
+    src = "~est" if mode_data["source"] == "estimate" else "  "
+    return f"{mode_data['minutes']:>3} min  {mode_data['distance_km']:>5.1f} km  {src}"
+
+
+def run_pair(a, b):
+    print(f"\n  {a.name_en or a.name_pl}")
+    print(f"  → {b.name_en or b.name_pl}")
+    print(f"  ({a.latitude:.4f},{a.longitude:.4f}) → ({b.latitude:.4f},{b.longitude:.4f})")
+    print()
+
+    times = get_travel_times(a.latitude, a.longitude, b.latitude, b.longitude)
+    for mode, icon in ICONS.items():
+        data = times[mode]
+        print(f"  {icon}  {mode:<8}  {fmt(data)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test transport travel times between attractions")
+    parser.add_argument("--pair", nargs=2, type=int, metavar=("FROM", "TO"),
+                        help="Test a specific pair by DB row index (0-based)")
+    parser.add_argument("--list", action="store_true", help="List all attractions with indices")
+    args = parser.parse_args()
+
+    api_configured = settings.google_maps_api_key and settings.google_maps_api_key != "your_key_here"
+
+    print(SEPARATOR)
+    print("  Transport Service Test")
+    print(f"  Google API: {'✅ configured' if api_configured else '⚠️  not set — using Haversine estimates'}")
+    print(SEPARATOR)
+
+    db = next(get_db())
+    places = db.query(Place).filter(Place.latitude.isnot(None), Place.longitude.isnot(None)).all()
+
+    if not places:
+        print("  ❌ No places with coordinates found in DB.")
+        return
+
+    if args.list:
+        print("\n  Attractions with coordinates:\n")
+        for i, p in enumerate(places):
+            print(f"  [{i:2}]  {p.name_en or p.name_pl:<35} ({p.latitude:.4f}, {p.longitude:.4f})")
+        print()
+        return
+
+    if args.pair:
+        i, j = args.pair
+        if i >= len(places) or j >= len(places):
+            print(f"  ❌ Index out of range. Max index: {len(places) - 1}")
+            return
+        print(SEPARATOR)
+        run_pair(places[i], places[j])
+        print()
+        return
+
+    # Default: test all consecutive pairs
+    print(f"\n  Testing {len(places) - 1} consecutive pairs ({len(places)} attractions)\n")
+    for i in range(len(places) - 1):
+        print(SEPARATOR)
+        run_pair(places[i], places[i + 1])
+
+    print(f"\n{SEPARATOR}")
+    print("  Done.")
+    if not api_configured:
+        print("  Tip: set GOOGLE_MAPS_API_KEY in .env to get real times from Google.")
+    print(SEPARATOR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds /transport/times endpoint that queries Google Distance Matrix API for walking, cycling, driving, and tram travel times between two coordinates. Falls back to Haversine estimates (rounded to nearest 5 min) when the API key is not configured or the request fails.

Also adds scripts/test_transport.py for terminal-only testing of all attraction pairs without needing the frontend.