### PR TITLE
feat: move multi-day itinerary planning to the backend

### DIFF
--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -2,8 +2,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.models.place import Place
-from app.schemas.itinerary import ItineraryRequest
-from app.services.planner_service import schedule_itinerary
+from app.schemas.itinerary import ItineraryRequest, ItineraryPlanRequest
+from app.services.planner_service import (
+    schedule_itinerary,
+    build_daily_itinerary,
+    place_to_attraction,
+)
 
 router = APIRouter()
 
@@ -30,3 +34,28 @@ async def create_plan(request: ItineraryRequest, db: Session = Depends(get_db)):
         "items": items,
         "count": len(scheduled),
     }
+
+
+@router.post("/generate")
+async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depends(get_db)):
+    """
+    Build a full multi-day itinerary (clock times, travel, breaks, overflow).
+    place_ids order is preserved so the greedy packer respects the user's selection.
+    """
+    places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
+
+    if not places:
+        raise HTTPException(status_code=404, detail="No places found for given IDs")
+
+    # Preserve the order the client sent, since packing is order-sensitive.
+    by_id = {p.id: p for p in places}
+    attractions = [place_to_attraction(by_id[pid]) for pid in request.place_ids if pid in by_id]
+
+    return build_daily_itinerary(
+        attractions,
+        num_days=request.num_days,
+        intensity=request.intensity,
+        start_time=request.start_time,
+        break_duration_minutes=request.break_duration_minutes,
+        transport_mode=request.transport_mode,
+    )

--- a/travel-guide/backend/app/core/planning_config.py
+++ b/travel-guide/backend/app/core/planning_config.py
@@ -1,0 +1,30 @@
+"""
+Planning constants — ported 1:1 from the frontend (constants.js) so the backend
+planner produces results identical to the original client-side algorithm.
+"""
+
+# Itinerary intensity levels: per-day time budget and attraction cap.
+# max_attractions_per_day = None means "no cap".
+INTENSITY_OPTIONS = [
+    {"key": "relaxed",  "max_minutes_per_day": 240, "max_attractions_per_day": 3},
+    {"key": "moderate", "max_minutes_per_day": 360, "max_attractions_per_day": 5},
+    {"key": "intense",  "max_minutes_per_day": 480, "max_attractions_per_day": None},
+]
+
+# Transport modes and the average speed (km/h) used for travel-time estimates.
+TRANSPORT_OPTIONS = [
+    {"key": "walking", "speed_kmh": 5},
+    {"key": "cycling", "speed_kmh": 15},
+    {"key": "transit", "speed_kmh": 20},
+]
+
+_DEFAULT_INTENSITY = INTENSITY_OPTIONS[1]  # moderate
+_DEFAULT_SPEED = 5  # walking
+
+
+def get_intensity_config(key: str) -> dict:
+    return next((o for o in INTENSITY_OPTIONS if o["key"] == key), _DEFAULT_INTENSITY)
+
+
+def get_transport_speed(mode: str) -> int:
+    return next((o["speed_kmh"] for o in TRANSPORT_OPTIONS if o["key"] == mode), _DEFAULT_SPEED)

--- a/travel-guide/backend/app/schemas/itinerary.py
+++ b/travel-guide/backend/app/schemas/itinerary.py
@@ -7,3 +7,13 @@ class ItineraryRequest(BaseModel):
     intensity: str = "moderate"
     start_time: str = "09:00"
     break_duration_minutes: int = 30
+
+
+class ItineraryPlanRequest(BaseModel):
+    """Request for the multi-day planner. place_ids order is preserved."""
+    place_ids: List[int]
+    num_days: int = 1
+    intensity: str = "moderate"
+    start_time: str = "09:00"
+    break_duration_minutes: int = 30
+    transport_mode: str = "walking"

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -1,3 +1,9 @@
+import math
+import re
+
+from app.core.planning_config import get_intensity_config, get_transport_speed
+
+
 def _time_to_minutes(t: str) -> int:
     h, m = map(int, t.split(":"))
     return h * 60 + m
@@ -55,3 +61,191 @@ def schedule_itinerary(places, total_minutes, start_time="09:00", break_duration
         })
 
     return plan
+
+
+# ---------------------------------------------------------------------------
+# Multi-day planner
+#
+# Ported 1:1 from the frontend (utils.js -> buildDailyItinerary) so the backend
+# produces results identical to the original client-side algorithm. Output uses
+# the same field names as the frontend `days` structure (camelCase) so the
+# frontend can swap its local call for a fetch with no shape changes.
+# ---------------------------------------------------------------------------
+
+def _duration_minutes(duration: str | None) -> int:
+    """Parse 'Xh Ymin' / 'Xh' / 'Y min' into minutes. Empty -> 0 (matches JS)."""
+    if not duration:
+        return 0
+    total = 0
+    hours = re.search(r"(\d+)\s*h", duration)
+    mins = re.search(r"(\d+)\s*min", duration)
+    if hours:
+        total += int(hours.group(1)) * 60
+    if mins:
+        total += int(mins.group(1))
+    return total
+
+
+def _js_round2(value: float) -> float:
+    """Match JS Math.round(value * 100) / 100 (round half up)."""
+    return math.floor(value * 100 + 0.5) / 100
+
+
+def _haversine_km(a: dict | None, b: dict | None) -> float | None:
+    if not a or not b:
+        return None
+    if a.get("latitude") is None or a.get("longitude") is None:
+        return None
+    if b.get("latitude") is None or b.get("longitude") is None:
+        return None
+    R = 6371
+    lat1 = math.radians(a["latitude"])
+    lat2 = math.radians(b["latitude"])
+    d_lat = math.radians(b["latitude"] - a["latitude"])
+    d_lon = math.radians(b["longitude"] - a["longitude"])
+    h = math.sin(d_lat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(d_lon / 2) ** 2
+    return R * 2 * math.atan2(math.sqrt(h), math.sqrt(1 - h))
+
+
+def _haversine_minutes(a: dict | None, b: dict | None, speed_kmh: int = 5) -> int:
+    """Straight-line travel minutes, rounded UP to the nearest 5 (matches JS)."""
+    km = _haversine_km(a, b)
+    if km is None:
+        return 0
+    raw = (km / speed_kmh) * 60
+    return math.ceil(raw / 5) * 5
+
+
+def _recalculate_item_times(items: list[dict], start_time: str) -> list[dict]:
+    """Assign sequential start_at/end_at clock times to every item in a day."""
+    current = _time_to_minutes(start_time)
+    result = []
+    for item in items:
+        duration = (
+            _duration_minutes(item.get("duration"))
+            if item["type"] == "attraction"
+            else item["duration"]
+        )
+        start_at = _minutes_to_time(current)
+        current += duration
+        end_at = _minutes_to_time(current)
+        result.append({**item, "start_at": start_at, "end_at": end_at})
+    return result
+
+
+def _compute_day_items(attractions, travel_minutes, break_durations, start_time, travel_km=None):
+    """Build the flat attraction/travel/break list for one day, with clock times."""
+    travel_km = travel_km or []
+    raw_items = []
+    last_index = len(attractions) - 1
+    for i, attr in enumerate(attractions):
+        raw_items.append({"type": "attraction", **attr})
+        if i < last_index:
+            travel = travel_minutes[i] if i < len(travel_minutes) else 0
+            raw_items.append({
+                "type": "travel",
+                "id": f"travel-{attr['id']}",
+                "duration": travel,
+                "gapIndex": i,
+                "distanceKm": travel_km[i] if i < len(travel_km) else None,
+            })
+            break_dur = break_durations[i] if i < len(break_durations) else None
+            if break_dur is not None:
+                raw_items.append({
+                    "type": "break",
+                    "id": f"break-{attr['id']}",
+                    "duration": break_dur,
+                    "gapIndex": i,
+                })
+    return _recalculate_item_times(raw_items, start_time)
+
+
+def place_to_attraction(place) -> dict:
+    """Serialize a Place ORM row into the attraction dict the planner expects."""
+    return {
+        "id": place.id,
+        "name_en": place.name_en,
+        "name_pl": place.name_pl,
+        "category": place.category,
+        "description": place.description,
+        "opening_hours": place.opening_hours,
+        "duration": place.duration,
+        "price_range": place.price_range,
+        "image_url": place.image_url,
+        "latitude": place.latitude,
+        "longitude": place.longitude,
+    }
+
+
+def build_daily_itinerary(
+    attractions: list[dict],
+    num_days: int,
+    intensity: str = "moderate",
+    start_time: str = "09:00",
+    break_duration_minutes: int = 30,
+    transport_mode: str = "walking",
+) -> dict:
+    """
+    Greedily pack ordered attractions into days under the intensity budget,
+    inserting travel time and (for relaxed) breaks. Returns {"days", "overflow"}.
+    """
+    config = get_intensity_config(intensity)
+    max_minutes = config["max_minutes_per_day"]
+    max_attractions = config["max_attractions_per_day"]
+    is_relaxed = intensity == "relaxed"
+    speed = get_transport_speed(transport_mode)
+
+    days = [
+        {
+            "attractions": [],
+            "travelMinutes": [],
+            "travelKm": [],
+            "breakDurations": [],
+            "items": [],
+            "totalMinutes": 0,
+        }
+        for _ in range(num_days)
+    ]
+    overflow = []
+
+    for attraction in attractions:
+        duration = _duration_minutes(attraction.get("duration"))
+
+        day_index = -1
+        for idx, day in enumerate(days):
+            last = day["attractions"][-1] if day["attractions"] else None
+            travel = _haversine_minutes(last, attraction, speed) if last else 0
+            break_overhead = break_duration_minutes if (is_relaxed and day["attractions"]) else 0
+            fits_time = day["totalMinutes"] + travel + break_overhead + duration <= max_minutes
+            fits_count = max_attractions is None or len(day["attractions"]) < max_attractions
+            if fits_time and fits_count:
+                day_index = idx
+                break
+
+        if day_index != -1:
+            day = days[day_index]
+            if day["attractions"]:
+                last = day["attractions"][-1]
+                travel = _haversine_minutes(last, attraction, speed)
+                km = _haversine_km(last, attraction)
+                day["travelMinutes"].append(travel)
+                day["travelKm"].append(_js_round2(km) if km is not None else None)
+                day["totalMinutes"] += travel
+                day["breakDurations"].append(break_duration_minutes if is_relaxed else None)
+                if is_relaxed:
+                    day["totalMinutes"] += break_duration_minutes
+            day["attractions"].append(attraction)
+            day["totalMinutes"] += duration
+        else:
+            overflow.append(attraction)
+
+    for day in days:
+        day["items"] = _compute_day_items(
+            day["attractions"],
+            day["travelMinutes"],
+            day["breakDurations"],
+            start_time,
+            day["travelKm"],
+        )
+
+    return {"days": days, "overflow": overflow}

--- a/travel-guide/backend/scripts/test_planner.py
+++ b/travel-guide/backend/scripts/test_planner.py
@@ -1,0 +1,111 @@
+"""
+Terminal test for the multi-day itinerary planner — no frontend needed.
+
+Usage (from backend/, with venv active):
+    python scripts/test_planner.py --list
+    python scripts/test_planner.py --ids 1,2,3,8,5,6,7 --days 2 --intensity relaxed
+    python scripts/test_planner.py                      # default: first 6 places, 1 day
+
+Options:
+    --list                 show all places with id / duration / coords
+    --ids 1,2,3            ordered place ids to plan (default: first 6)
+    --days N               number of days (default 1)
+    --intensity KEY        relaxed | moderate | intense (default moderate)
+    --start HH:MM          daily start time (default 09:00)
+    --break N              break minutes for relaxed days (default 30)
+    --transport MODE       walking | cycling | transit (default walking)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running as a plain script: add backend/ to the import path.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.db.session import SessionLocal
+from app.models.place import Place
+from app.services.planner_service import build_daily_itinerary, place_to_attraction
+
+
+def list_places(db):
+    rows = db.query(Place).order_by(Place.id).all()
+    print(f"\n{len(rows)} places:\n")
+    for p in rows:
+        name = p.name_en or p.name_pl
+        print(f"  {p.id:>3}  {str(p.duration or '-'):<10}  "
+              f"({p.latitude}, {p.longitude})  {name}")
+    print()
+
+
+def print_plan(plan):
+    for i, day in enumerate(plan["days"]):
+        print(f"\n=== Day {i + 1}  ·  {day['totalMinutes']} min total "
+              f"({day['totalMinutes'] // 60}h {day['totalMinutes'] % 60:02d}m) ===")
+        if not day["items"]:
+            print("  (empty)")
+            continue
+        for item in day["items"]:
+            t = item["type"]
+            window = f"{item['start_at']}–{item['end_at']}"
+            if t == "attraction":
+                name = item.get("name_en") or item.get("name_pl")
+                print(f"  {window}  📍 {name}  ({item.get('duration')})")
+            elif t == "travel":
+                if item["duration"] > 0:
+                    dist = f" · {item['distanceKm']} km" if item["distanceKm"] is not None else ""
+                    print(f"  {window}     ↳ travel {item['duration']} min{dist}")
+            elif t == "break":
+                print(f"  {window}     ☕ break {item['duration']} min")
+
+    if plan["overflow"]:
+        names = [a.get("name_en") or a.get("name_pl") for a in plan["overflow"]]
+        print(f"\n⚠ Overflow (did not fit): {', '.join(names)}")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--ids", type=str, default=None)
+    parser.add_argument("--days", type=int, default=1)
+    parser.add_argument("--intensity", type=str, default="moderate")
+    parser.add_argument("--start", type=str, default="09:00")
+    parser.add_argument("--break", dest="brk", type=int, default=30)
+    parser.add_argument("--transport", type=str, default="walking")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        if args.list:
+            list_places(db)
+            return
+
+        if args.ids:
+            ids = [int(x) for x in args.ids.split(",") if x.strip()]
+        else:
+            ids = [p.id for p in db.query(Place).order_by(Place.id).limit(6).all()]
+
+        places = db.query(Place).filter(Place.id.in_(ids)).all()
+        by_id = {p.id: p for p in places}
+        attractions = [place_to_attraction(by_id[i]) for i in ids if i in by_id]
+
+        print(f"\nPlanning {len(attractions)} attractions over {args.days} day(s)  ·  "
+              f"intensity={args.intensity}  start={args.start}  "
+              f"transport={args.transport}  break={args.brk}min")
+
+        plan = build_daily_itinerary(
+            attractions,
+            num_days=args.days,
+            intensity=args.intensity,
+            start_time=args.start,
+            break_duration_minutes=args.brk,
+            transport_mode=args.transport,
+        )
+        print_plan(plan)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Moves the multi-day itinerary algorithm from the frontend into the backend as a real endpoint.

**New:** `POST /itinerary/generate` — takes ordered `place_ids` + trip settings, returns the full plan (per-day clock times, travel time between stops, breaks, and overflow).

The algorithm is ported 1:1 from the frontend `buildDailyItinerary`, and the response uses the **same field shape** (camelCase `days`/`items`), so frontend integration is a near drop-in: replace the local `buildDailyItinerary(...)` call in `App.jsx` with a `fetch` to this endpoint.

**Not in this PR:** frontend wiring (the client still plans locally for now), and opening-hours validation (deferred until the places dataset has cleaner data).

**Testing:** `scripts/test_planner.py` (terminal, no frontend needed) + verified live via curl. The old `/itinerary/plan` is untouched.