### PR TITLE
Connect preferences API endpoints

### DIFF
--- a/travel-guide/frontend/src/App.jsx
+++ b/travel-guide/frontend/src/App.jsx
@@ -110,31 +110,40 @@ function App() {
 
   const currentPreferences = {
     selectedCategories,
-    arrivalDate,
-    numDays,
     startTime,
     intensity,
     transportMode,
+    breakDurationMinutes: 30,
   };
 
   const handleSavePreferences = async () => {
-    const result = await savePreferences(currentPreferences);
-    setPreferenceStatus(result.message);
+    try {
+      await savePreferences(currentPreferences);
+      setPreferenceStatus("Preferences saved successfully.");
+    } catch {
+      setPreferenceStatus("Could not save preferences. Please check that the backend is running.");
+    }
   };
 
   const handleLoadPreferences = async () => {
-    const result = await loadPreferences();
+    try {
+      const result = await loadPreferences(1);
 
-    if (result.available && result.preferences) {
-      setSelectedCategories(result.preferences.selectedCategories ?? []);
-      setArrivalDate(result.preferences.arrivalDate ?? "");
-      setNumDays(result.preferences.numDays ?? 1);
-      setStartTime(result.preferences.startTime ?? "09:00");
-      setIntensity(result.preferences.intensity ?? "moderate");
-      setTransportMode(result.preferences.transportMode ?? "walking");
+      if (result.preferences) {
+        setSelectedCategories(result.preferences.selectedCategories ?? []);
+        setStartTime(result.preferences.startTime ?? "09:00");
+        setIntensity(result.preferences.intensity ?? "moderate");
+        setTransportMode(result.preferences.transportMode ?? "walking");
+      }
+
+      setPreferenceStatus(
+        result.is_new_user
+          ? "No saved preferences found yet. You can create them now."
+          : "Preferences loaded successfully."
+      );
+    } catch {
+      setPreferenceStatus("Could not load preferences. Please check that the backend is running.");
     }
-
-    setPreferenceStatus(result.message);
   };
 
   const generateItinerary = () => {

--- a/travel-guide/frontend/src/services/api.js
+++ b/travel-guide/frontend/src/services/api.js
@@ -1,15 +1,38 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
+const DEFAULT_USER_ID = 1;
+
+const FRONTEND_TO_BACKEND_INTENSITY = {
+  relaxed: "low",
+  moderate: "moderate",
+  intense: "high",
+};
+
+const BACKEND_TO_FRONTEND_INTENSITY = {
+  low: "relaxed",
+  moderate: "moderate",
+  high: "intense",
+};
+
+function getPreferenceUserId() {
+  try {
+    localStorage.setItem("travelPlannerUserId", String(DEFAULT_USER_ID));
+  } catch {
+    // localStorage can be unavailable in some browser privacy modes.
+  }
+
+  return DEFAULT_USER_ID;
+}
 
 async function request(path, options = {}) {
   let response;
 
   try {
     response = await fetch(`${API_BASE_URL}${path}`, {
+      ...options,
       headers: {
         "Content-Type": "application/json",
         ...options.headers,
       },
-      ...options,
     });
   } catch {
     throw new Error("Network request failed");
@@ -30,20 +53,36 @@ export function fetchCategories() {
   return request("/categories");
 }
 
-export async function savePreferences(preferences) {
-  // TODO: Connect this to the backend preference save endpoint once PR #109 is confirmed ready.
-  return {
-    available: false,
-    preferences,
-    message: "Preference saving will be available once the backend endpoint is ready.",
+export function savePreferences(preferences) {
+  const payload = {
+    user_id: getPreferenceUserId(),
+    intensity: FRONTEND_TO_BACKEND_INTENSITY[preferences.intensity] ?? "moderate",
+    transport_mode: preferences.transportMode ?? "walking",
+    break_duration_minutes: preferences.breakDurationMinutes ?? 30,
+    start_time: preferences.startTime ?? "09:00",
+    selected_categories: preferences.selectedCategories ?? [],
   };
+
+  return request("/preferences/save", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 }
 
-export async function loadPreferences() {
-  // TODO: Connect this to the backend preference load endpoint once PR #109 is confirmed ready.
+export async function loadPreferences(userId = getPreferenceUserId()) {
+  const data = await request(`/preferences/load/${userId}`);
+  const preferences = data.preferences;
+
   return {
-    available: false,
-    preferences: null,
-    message: "Preference loading will be available once the backend endpoint is ready.",
+    ...data,
+    preferences: preferences
+      ? {
+          selectedCategories: preferences.selected_categories ?? [],
+          intensity: BACKEND_TO_FRONTEND_INTENSITY[preferences.intensity] ?? "moderate",
+          transportMode: preferences.transport_mode ?? "walking",
+          breakDurationMinutes: preferences.break_duration_minutes ?? 30,
+          startTime: preferences.start_time ?? "09:00",
+        }
+      : null,
   };
 }


### PR DESCRIPTION
## Summary

Connects the existing frontend preferences UI to the real backend preference endpoints added in PR #109.

## Changes

- Connects `Save Preferences` to `POST /preferences/save`
- Connects `Load Preferences` to `GET /preferences/load/1`
- Uses fixed `user_id: 1` until authentication exists
- Maps frontend intensity values to backend values:
  - `relaxed` → `low`
  - `moderate` → `moderate`
  - `intense` → `high`
- Maps backend intensity values back to frontend values on load
- Saves supported backend fields only:
  - selected categories
  - intensity
  - transport mode
  - start time
  - break duration minutes
- Does not send arrival date or number of days because the backend endpoint does not support them yet
- Keeps existing attraction loading, filtering, selection, itinerary generation, maps, transport, intensity, and break management flows unchanged

## User Messages

- Save success: `Preferences saved successfully.`
- Save failure: `Could not save preferences. Please check that the backend is running.`
- First-time load: `No saved preferences found yet. You can create them now.`
- Load failure: `Could not load preferences. Please check that the backend is running.`

## Checks

- `npm install`
- `npm run build`
- `npm run lint`

## Issues

Addresses #72  
Addresses #73  
Partially supports #74  
Builds on #71