### PR TITLE
Add frontend itinerary validation

### DIFF
--- a/travel-guide/docs/frontend-personalization-quality-checklist.md
+++ b/travel-guide/docs/frontend-personalization-quality-checklist.md
@@ -1,0 +1,53 @@
+# Frontend Personalization Quality Checklist
+
+Use this checklist when validating itinerary personalization from the browser.
+
+## Test Profiles
+
+### Culture-focused relaxed trip
+- Select categories: `culture`, `art`, `landmark`
+- Intensity: `Relaxed`
+- Transport: `Walking`
+- Days: `2`
+- Expected result:
+  - Itinerary prefers selected categories.
+  - No day exceeds the relaxed daily limit.
+  - Breaks can be added only while the day remains feasible.
+  - Overflow appears instead of forcing an impossible schedule.
+
+### Outdoor and family moderate trip
+- Select categories: `outdoor`, `family`, `food`
+- Intensity: `Moderate`
+- Transport: `Transit`
+- Days: `1`
+- Expected result:
+  - Planned attractions match the selected categories.
+  - Travel slots and break slots remain in chronological order.
+  - Late or unrealistic schedules show visible warnings.
+
+### High-intensity mixed trip
+- Select all categories.
+- Intensity: `Intense`
+- Transport: `Cycling`
+- Days: `1`
+- Expected result:
+  - The app creates a fuller day than relaxed or moderate modes.
+  - Reordering attractions does not create invalid schedules.
+  - Long travel segments are flagged.
+
+## Regression Checks
+
+- Generate itinerary with no backend running for `/places`; the frontend shows the API error state.
+- Select and deselect categories; attraction filtering still follows the selected categories.
+- Select attractions, generate itinerary, reorder attractions, remove attractions, add breaks, remove breaks, and change break duration.
+- Try increasing a break until the day would exceed the intensity limit; the app blocks the change and shows a message.
+- Try profiles with narrow categories and confirm the app does not generate irrelevant attractions when matching attractions exist.
+- Confirm no empty itinerary is produced when selected attractions are available.
+
+## Related Issues
+
+- #83 Test personalization quality
+- #95 Validate schedule after breaks
+- #106 Validate realistic schedules
+- #68 Validate itinerary feasibility
+- #78 Prevent scheduling conflicts

--- a/travel-guide/frontend/src/App.jsx
+++ b/travel-guide/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import {
   buildDailyItinerary, computeDayItems, computeTravelMinutes, computeTravelKm,
   getTransportSpeed,
 } from "./utils";
+import { getDayScheduleValidation } from "./itineraryValidation";
 import { fetchPlaces, loadPreferences, savePreferences } from "./services/api";
 import AttractionDetailsModal from "./components/AttractionDetailsModal";
 import HomePage from "./pages/HomePage";
@@ -35,6 +36,7 @@ function App() {
   const [startTime, setStartTime] = useState("09:00");
   const [transportMode, setTransportMode] = useState("walking");
   const [itineraryDays, setItineraryDays] = useState(null);
+  const [scheduleNotice, setScheduleNotice] = useState("");
 
   const retryLoadAttractions = useCallback(async () => {
     setIsLoadingAttractions(true);
@@ -139,38 +141,65 @@ function App() {
 
   const generateItinerary = () => {
     setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, intensity, startTime, 30, transportMode));
+    setScheduleNotice("");
     setPage("itinerary");
   };
 
   const changeIntensity = (newIntensity) => {
     setIntensity(newIntensity);
     setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, newIntensity, startTime, 30, transportMode));
+    setScheduleNotice("");
   };
 
-  const moveAttractionInDay = (dayIndex, attractionIndex, dir) => {
-    const targetIndex = dir === "up" ? attractionIndex - 1 : attractionIndex + 1;
+  const buildUpdatedDay = (day, newAttractions, newBreakDurations) => {
+    const speed = getTransportSpeed(transportMode);
+    const newTravelMinutes = computeTravelMinutes(newAttractions, speed);
+    const newTravelKm = computeTravelKm(newAttractions);
+    const newItems = computeDayItems(newAttractions, newTravelMinutes, newBreakDurations, startTime, newTravelKm);
+    return {
+      ...day,
+      attractions: newAttractions,
+      travelMinutes: newTravelMinutes,
+      travelKm: newTravelKm,
+      breakDurations: newBreakDurations,
+      items: newItems,
+      totalMinutes: totalFromItems(newItems),
+    };
+  };
+
+  const applyDayUpdate = (dayIndex, updatedDay, actionLabel) => {
+    const validation = getDayScheduleValidation(updatedDay, intensity);
+    if (!validation.isValid) {
+      setScheduleNotice(`${actionLabel} was not applied: ${validation.blockers[0]}`);
+      return;
+    }
+
+    setScheduleNotice("");
     setItineraryDays((prev) => {
-      const day = prev.days[dayIndex];
-      if (targetIndex < 0 || targetIndex >= day.attractions.length) return prev;
-      const newAttractions = [...day.attractions];
-      [newAttractions[attractionIndex], newAttractions[targetIndex]] =
-        [newAttractions[targetIndex], newAttractions[attractionIndex]];
-      const speed = getTransportSpeed(transportMode);
-      const newTravelMinutes = computeTravelMinutes(newAttractions, speed);
-      const newTravelKm = computeTravelKm(newAttractions);
-      const newItems = computeDayItems(newAttractions, newTravelMinutes, day.breakDurations, startTime, newTravelKm);
+      if (!prev) return prev;
       return {
         ...prev,
-        days: prev.days.map((d, i) =>
-          i === dayIndex
-            ? { ...d, attractions: newAttractions, travelMinutes: newTravelMinutes, travelKm: newTravelKm, items: newItems, totalMinutes: totalFromItems(newItems) }
-            : d
-        ),
+        days: prev.days.map((day, index) => (index === dayIndex ? updatedDay : day)),
       };
     });
   };
 
+  const moveAttractionInDay = (dayIndex, attractionIndex, dir) => {
+    const day = itineraryDays?.days[dayIndex];
+    if (!day) return;
+
+    const targetIndex = dir === "up" ? attractionIndex - 1 : attractionIndex + 1;
+    if (targetIndex < 0 || targetIndex >= day.attractions.length) return;
+
+    const newAttractions = [...day.attractions];
+    [newAttractions[attractionIndex], newAttractions[targetIndex]] =
+      [newAttractions[targetIndex], newAttractions[attractionIndex]];
+    const updatedDay = buildUpdatedDay(day, newAttractions, [...day.breakDurations]);
+    applyDayUpdate(dayIndex, updatedDay, "Reorder");
+  };
+
   const removeFromItinerary = (attractionId) => {
+    setScheduleNotice("");
     setSelectedAttractions((prev) => prev.filter((a) => a.id !== attractionId));
     setItineraryDays((prev) => {
       if (!prev) return prev;
@@ -197,52 +226,51 @@ function App() {
   };
 
   const addBreak = (dayIndex, gapIndex) => {
-    setItineraryDays((prev) => {
-      const day = prev.days[dayIndex];
-      const newBreakDurations = [...day.breakDurations];
-      newBreakDurations[gapIndex] = 30;
-      const newItems = computeDayItems(day.attractions, day.travelMinutes, newBreakDurations, startTime);
-      return {
-        ...prev,
-        days: prev.days.map((d, i) =>
-          i === dayIndex
-            ? { ...d, breakDurations: newBreakDurations, items: newItems, totalMinutes: totalFromItems(newItems) }
-            : d
-        ),
-      };
-    });
+    const day = itineraryDays?.days[dayIndex];
+    if (!day) return;
+
+    const newBreakDurations = [...day.breakDurations];
+    newBreakDurations[gapIndex] = 30;
+    const updatedDay = buildUpdatedDay(day, day.attractions, newBreakDurations);
+    applyDayUpdate(dayIndex, updatedDay, "Break");
   };
 
   const removeBreak = (dayIndex, gapIndex) => {
+    const day = itineraryDays?.days[dayIndex];
+    if (!day) return;
+
+    const newBreakDurations = [...day.breakDurations];
+    newBreakDurations[gapIndex] = null;
+    const updatedDay = buildUpdatedDay(day, day.attractions, newBreakDurations);
+    setScheduleNotice("");
     setItineraryDays((prev) => {
-      const day = prev.days[dayIndex];
-      const newBreakDurations = [...day.breakDurations];
-      newBreakDurations[gapIndex] = null;
-      const newItems = computeDayItems(day.attractions, day.travelMinutes, newBreakDurations, startTime);
+      if (!prev) return prev;
       return {
         ...prev,
-        days: prev.days.map((d, i) =>
-          i === dayIndex
-            ? { ...d, breakDurations: newBreakDurations, items: newItems, totalMinutes: totalFromItems(newItems) }
-            : d
-        ),
+        days: prev.days.map((currentDay, index) => (index === dayIndex ? updatedDay : currentDay)),
       };
     });
   };
 
   const changeBreakDuration = (dayIndex, gapIndex, delta) => {
+    const day = itineraryDays?.days[dayIndex];
+    if (!day) return;
+
+    const newBreakDurations = [...day.breakDurations];
+    newBreakDurations[gapIndex] = Math.max(15, Math.min(120, (newBreakDurations[gapIndex] ?? 30) + delta));
+    const updatedDay = buildUpdatedDay(day, day.attractions, newBreakDurations);
+
+    if (delta > 0) {
+      applyDayUpdate(dayIndex, updatedDay, "Break duration change");
+      return;
+    }
+
+    setScheduleNotice("");
     setItineraryDays((prev) => {
-      const day = prev.days[dayIndex];
-      const newBreakDurations = [...day.breakDurations];
-      newBreakDurations[gapIndex] = Math.max(15, Math.min(120, (newBreakDurations[gapIndex] ?? 30) + delta));
-      const newItems = computeDayItems(day.attractions, day.travelMinutes, newBreakDurations, startTime);
+      if (!prev) return prev;
       return {
         ...prev,
-        days: prev.days.map((d, i) =>
-          i === dayIndex
-            ? { ...d, breakDurations: newBreakDurations, items: newItems, totalMinutes: totalFromItems(newItems) }
-            : d
-        ),
+        days: prev.days.map((currentDay, index) => (index === dayIndex ? updatedDay : currentDay)),
       };
     });
   };
@@ -302,6 +330,7 @@ function App() {
           departureDate={departureDate}
           onBack={() => setPage("results")}
           transportMode={transportMode}
+          scheduleNotice={scheduleNotice}
           onChangeIntensity={changeIntensity}
           onRegenerate={generateItinerary}
           onMoveAttraction={moveAttractionInDay}

--- a/travel-guide/frontend/src/itineraryValidation.js
+++ b/travel-guide/frontend/src/itineraryValidation.js
@@ -1,0 +1,83 @@
+import { INTENSITY_OPTIONS } from "./constants";
+
+const LATEST_REASONABLE_END = 22 * 60;
+const MIDNIGHT = 24 * 60;
+const LONG_TRAVEL_MINUTES = 90;
+
+function timeToMinutes(timeStr) {
+  if (!timeStr || !/^\d{2}:\d{2}$/.test(timeStr)) return null;
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+function formatClock(totalMinutes) {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
+
+function getIntensityConfig(intensityKey) {
+  return INTENSITY_OPTIONS.find((option) => option.key === intensityKey) ?? INTENSITY_OPTIONS[1];
+}
+
+export function getDayScheduleValidation(day, intensityKey) {
+  const config = getIntensityConfig(intensityKey);
+  const blockers = [];
+  const warnings = [];
+
+  if (!day) {
+    return { blockers, warnings, isValid: true };
+  }
+
+  if (day.totalMinutes > config.maxMinutesPerDay) {
+    blockers.push(
+      `This day is over the ${config.label.toLowerCase()} limit. Shorten breaks, remove an attraction, or choose a higher intensity.`
+    );
+  }
+
+  if (day.items.length === 0) {
+    warnings.push("No attractions are planned for this day.");
+  }
+
+  let previousEnd = null;
+  day.items.forEach((item) => {
+    const start = timeToMinutes(item.start_at);
+    const end = timeToMinutes(item.end_at);
+
+    if (start !== null && end !== null) {
+      const adjustedEnd = end < start ? end + MIDNIGHT : end;
+
+      if (previousEnd !== null && start < previousEnd) {
+        blockers.push("This schedule has overlapping time slots.");
+      }
+
+      if (adjustedEnd >= MIDNIGHT) {
+        blockers.push("This schedule continues past midnight.");
+      } else if (adjustedEnd > LATEST_REASONABLE_END) {
+        warnings.push(`This schedule ends late (${formatClock(adjustedEnd)}).`);
+      }
+
+      previousEnd = adjustedEnd;
+    }
+
+    if (item.type === "travel" && item.duration >= LONG_TRAVEL_MINUTES) {
+      warnings.push(`A travel segment takes ${item.duration} minutes, which may be unrealistic for a compact day.`);
+    }
+  });
+
+  return {
+    blockers: [...new Set(blockers)],
+    warnings: [...new Set(warnings)],
+    isValid: blockers.length === 0,
+  };
+}
+
+export function getItineraryScheduleValidation(days, intensityKey) {
+  const dayValidations = days.map((day) => getDayScheduleValidation(day, intensityKey));
+  return {
+    dayValidations,
+    blockers: dayValidations.flatMap((validation) => validation.blockers),
+    warnings: dayValidations.flatMap((validation) => validation.warnings),
+    isValid: dayValidations.every((validation) => validation.isValid),
+  };
+}

--- a/travel-guide/frontend/src/pages/ItineraryPage.jsx
+++ b/travel-guide/frontend/src/pages/ItineraryPage.jsx
@@ -1,4 +1,5 @@
 import { INTENSITY_OPTIONS, TRANSPORT_OPTIONS } from "../constants";
+import { getItineraryScheduleValidation } from "../itineraryValidation";
 import { formatMinutes, formatDayDate } from "../utils";
 import ItineraryMap from "../components/ItineraryMap";
 
@@ -7,11 +8,13 @@ const TRANSPORT_ICONS = { walking: "🚶", cycling: "🚴", transit: "🚌" };
 export default function ItineraryPage({
   days, overflow, intensity, totalDuration, transportMode,
   arrivalDate, numDays, departureDate,
+  scheduleNotice,
   onBack, onChangeIntensity, onRegenerate,
   onMoveAttraction, onRemoveAttraction,
   onAddBreak, onRemoveBreak, onChangeBreakDuration,
 }) {
   const intensityConfig = INTENSITY_OPTIONS.find((o) => o.key === intensity);
+  const scheduleValidation = getItineraryScheduleValidation(days, intensity);
 
   return (
     <section className="itinerary">
@@ -46,12 +49,30 @@ export default function ItineraryPage({
         </button>
       </div>
 
+      {scheduleNotice && (
+        <div className="schedule-alert critical">
+          {scheduleNotice}
+        </div>
+      )}
+
+      {(scheduleValidation.blockers.length > 0 || scheduleValidation.warnings.length > 0) && (
+        <div className={scheduleValidation.isValid ? "schedule-alert" : "schedule-alert critical"}>
+          <strong>{scheduleValidation.isValid ? "Schedule warnings" : "Schedule needs attention"}</strong>
+          <ul>
+            {[...new Set([...scheduleValidation.blockers, ...scheduleValidation.warnings])].map((message) => (
+              <li key={message}>{message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <div className="itinerary-map-panel">
         <ItineraryMap days={days} />
       </div>
 
       {days.map((day, dayIndex) => {
         let attrCounter = 0;
+        const dayValidation = scheduleValidation.dayValidations[dayIndex];
 
         return (
           <div key={dayIndex} className="day-block">
@@ -69,6 +90,28 @@ export default function ItineraryPage({
               <div className="day-warning">
                 ⚠ This day is {formatMinutes(day.totalMinutes - intensityConfig.maxMinutesPerDay)} over
                 your <strong>{intensityConfig.label}</strong> limit — shorten a break or remove an attraction.
+              </div>
+            )}
+
+            {dayValidation?.blockers.length > 0 && (
+              <div className="day-warning critical">
+                <strong>Invalid schedule:</strong>
+                <ul>
+                  {dayValidation.blockers.map((message) => (
+                    <li key={message}>{message}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {dayValidation?.warnings.length > 0 && (
+              <div className="day-warning">
+                <strong>Schedule warning:</strong>
+                <ul>
+                  {dayValidation.warnings.map((message) => (
+                    <li key={message}>{message}</li>
+                  ))}
+                </ul>
               </div>
             )}
 

--- a/travel-guide/frontend/src/styles/ui.css
+++ b/travel-guide/frontend/src/styles/ui.css
@@ -81,6 +81,34 @@
   font-weight: 700;
 }
 
+.schedule-alert {
+  margin: 0 0 24px;
+  padding: 14px 18px;
+  border: 1px solid #fed7aa;
+  border-radius: 12px;
+  background: #fff7ed;
+  color: #9a3412;
+  font-size: 14px;
+}
+
+.schedule-alert.critical,
+.day-warning.critical {
+  background: #fff1f2;
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.schedule-alert ul,
+.day-warning ul {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.schedule-alert li,
+.day-warning li {
+  margin: 4px 0;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- Add frontend itinerary validation for daily limits, overlapping time slots, late schedules, past-midnight schedules, and long travel segments.
- Block break additions and break duration increases when they would make a day infeasible.
- Show visible itinerary-level and day-level warnings for unrealistic or invalid schedules.
- Add a manual frontend personalization quality checklist with test profiles and regression checks.

## Checks
- `npm install`
- `npm run lint`
- `npm run build`

## Related Issues
- Addresses #95
- Addresses #106
- Addresses #68
- Addresses #78
- Prepares/tests #83