### PR TITLE
feat: backend-driven itinerary planner with route optimisation

### DIFF
--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -2,16 +2,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.models.place import Place
-from app.schemas.itinerary import (
-    ItineraryRequest, ItineraryPlanRequest,
-    OptimizedItineraryRequest, FinalizeRequest,
-)
+from app.schemas.itinerary import ItineraryRequest, FinalizeRequest
 from app.services.planner_service import (
-    schedule_itinerary,
-    build_daily_itinerary,
-    build_optimized_itinerary,
+    build_itinerary,
     place_to_attraction,
-    rank_attractions,
     _compute_day_items,
     _duration_minutes,
 )
@@ -21,82 +15,13 @@ router = APIRouter()
 
 
 # ---------------------------------------------------------------------------
-# OBSOLETE — POST /itinerary/plan
-# Sprint 1 single-day scheduler. Takes a flat total_minutes cap and returns
-# a list of attractions that fit within it. No travel time, no multi-day,
-# no transport mode. The frontend never calls this; kept only for reference.
-# Remove together with ItineraryRequest once /plan-optimized is live.
+# POST /itinerary/plan
+# Backend-driven multi-day itinerary planner. Receives an unordered pool of
+# place_ids and returns an optimised route with per-day time windows,
+# per-day intensity overrides, start/end anchor support, and warnings.
 # ---------------------------------------------------------------------------
 @router.post("/plan")
-async def create_plan(request: ItineraryRequest, db: Session = Depends(get_db)):
-    places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
-
-    if not places:
-        raise HTTPException(status_code=404, detail="No places found for given IDs")
-    
-    categories = getattr(request, "selected_categories", [])
-    ranked_places = rank_attractions(places, categories)
-
-    items = schedule_itinerary(
-        ranked_places,
-        request.total_minutes,
-        start_time=request.start_time,
-        break_duration_minutes=request.break_duration_minutes,
-        intensity=request.intensity,
-    )
-
-    scheduled = [i for i in items if i["type"] == "attraction"]
-    return {
-        "total_minutes": request.total_minutes,
-        "start_time": request.start_time,
-        "intensity": request.intensity,
-        "items": items,
-        "count": len(scheduled),
-    }
-
-
-# ---------------------------------------------------------------------------
-# TO BE REPLACED — POST /itinerary/generate
-# Sprint 2 I3 multi-day planner. Accepts place_ids in the order the frontend
-# sent them (click order) and packs them greedily into days.
-# Will be replaced by /plan-optimized once the frontend is updated.
-# Remove together with ItineraryPlanRequest at that point.
-# ---------------------------------------------------------------------------
-@router.post("/generate")
-async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depends(get_db)):
-    places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
-
-    if not places:
-        raise HTTPException(status_code=404, detail="No places found for given IDs")
-
-    # Preserve the order the client sent, since packing is order-sensitive.
-    by_id = {p.id: p for p in places}
-    attractions = [place_to_attraction(by_id[pid]) for pid in request.place_ids if pid in by_id]
-
-    return build_daily_itinerary(
-        attractions,
-        num_days=request.num_days,
-        intensity=request.intensity,
-        start_time=request.start_time,
-        break_duration_minutes=request.break_duration_minutes,
-        transport_mode=request.transport_mode,
-    )
-
-
-# ---------------------------------------------------------------------------
-# CURRENT — POST /itinerary/plan-optimized
-# Backend-driven itinerary planner. Receives an unordered pool of place_ids
-# and handles ordering, time windows, per-day intensity, anchor-based routing,
-# and validation warnings. Steps added incrementally:
-#   Step 1 (done):  schema + skeleton
-#   Step 2 (done):  per-day time windows + per-day intensity
-#   Step 3 (done):  validation warnings (intensity vs window, inter-day rest)
-#   Step 4 (done):  anchor resolution (Stary Rynek default, prev/next day logic)
-#   Step 5 (done):  route optimization (nearest-neighbor + 2-opt)
-#   Step 6 (done):  Google finalization endpoint for accurate travel times
-# ---------------------------------------------------------------------------
-@router.post("/plan-optimized")
-async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depends(get_db)):
+async def plan_itinerary(request: ItineraryRequest, db: Session = Depends(get_db)):
     places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
 
     if not places:
@@ -105,7 +30,6 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
     by_id = {p.id: p for p in places}
     attractions = [place_to_attraction(by_id[pid]) for pid in request.place_ids if pid in by_id]
 
-    # Serialize days_config to plain dicts so planner_service has no Pydantic dependency.
     days_config = [
         dc.model_dump() if dc is not None else None
         for dc in request.days_config
@@ -113,7 +37,7 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
 
     pins = [p.model_dump() for p in request.pins] if request.pins else None
 
-    return build_optimized_itinerary(
+    return build_itinerary(
         attractions,
         num_days=request.num_days,
         global_intensity=request.intensity,
@@ -123,19 +47,19 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
         break_duration_minutes=request.break_duration_minutes,
         days_config=days_config,
         pins=pins,
+        selected_categories=request.selected_categories,
     )
 
 
 # ---------------------------------------------------------------------------
 # POST /itinerary/finalize
-# Called once the user approves the ordering from /plan-optimized.
+# Called once the user approves the ordering from /plan.
 # Replaces haversine travel estimates with real Google Distance Matrix times
 # for the selected transport mode. Returns the same days shape so the frontend
 # can swap the displayed times without changing its data model.
 # ---------------------------------------------------------------------------
 @router.post("/finalize")
 async def finalize_itinerary(request: FinalizeRequest, db: Session = Depends(get_db)):
-    # Collect all place_ids across all days in one DB query.
     all_ids = [pid for day in request.days for pid in day.place_ids]
     places  = db.query(Place).filter(Place.id.in_(all_ids)).all()
     if not places:
@@ -159,7 +83,6 @@ async def finalize_itinerary(request: FinalizeRequest, db: Session = Depends(get
                 travel_km.append(leg["distance_km"])
                 sources.append(leg["source"])
             else:
-                # Missing coordinates — keep a zero placeholder.
                 travel_minutes.append(0)
                 travel_km.append(None)
                 sources.append("estimate")
@@ -167,7 +90,6 @@ async def finalize_itinerary(request: FinalizeRequest, db: Session = Depends(get
         break_durations = day_input.break_durations or [None] * max(0, len(atts) - 1)
         items = _compute_day_items(atts, travel_minutes, break_durations, day_input.start_time, travel_km)
 
-        # Tag each travel item with its source (google / estimate).
         for item in items:
             if item["type"] == "travel":
                 item["source"] = sources[item["gapIndex"]] if item["gapIndex"] < len(sources) else "estimate"

--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -2,14 +2,20 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.models.place import Place
-from app.schemas.itinerary import ItineraryRequest, ItineraryPlanRequest, OptimizedItineraryRequest
+from app.schemas.itinerary import (
+    ItineraryRequest, ItineraryPlanRequest,
+    OptimizedItineraryRequest, FinalizeRequest,
+)
 from app.services.planner_service import (
     schedule_itinerary,
     build_daily_itinerary,
     build_optimized_itinerary,
     place_to_attraction,
     rank_attractions,
+    _compute_day_items,
+    _duration_minutes,
 )
+from app.services.transport_service import get_single_travel_time
 
 router = APIRouter()
 
@@ -87,7 +93,7 @@ async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depend
 #   Step 3 (done):  validation warnings (intensity vs window, inter-day rest)
 #   Step 4 (done):  anchor resolution (Stary Rynek default, prev/next day logic)
 #   Step 5 (done):  route optimization (nearest-neighbor + 2-opt)
-#   Step 6:         Google finalization endpoint for accurate travel times
+#   Step 6 (done):  Google finalization endpoint for accurate travel times
 # ---------------------------------------------------------------------------
 @router.post("/plan-optimized")
 async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depends(get_db)):
@@ -115,3 +121,68 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
         break_duration_minutes=request.break_duration_minutes,
         days_config=days_config,
     )
+
+
+# ---------------------------------------------------------------------------
+# POST /itinerary/finalize
+# Called once the user approves the ordering from /plan-optimized.
+# Replaces haversine travel estimates with real Google Distance Matrix times
+# for the selected transport mode. Returns the same days shape so the frontend
+# can swap the displayed times without changing its data model.
+# ---------------------------------------------------------------------------
+@router.post("/finalize")
+async def finalize_itinerary(request: FinalizeRequest, db: Session = Depends(get_db)):
+    # Collect all place_ids across all days in one DB query.
+    all_ids = [pid for day in request.days for pid in day.place_ids]
+    places  = db.query(Place).filter(Place.id.in_(all_ids)).all()
+    if not places:
+        raise HTTPException(status_code=404, detail="No places found for given IDs")
+    by_id = {p.id: place_to_attraction(p) for p in places}
+
+    result_days = []
+    for day_input in request.days:
+        atts = [by_id[pid] for pid in day_input.place_ids if pid in by_id]
+
+        travel_minutes, travel_km, sources = [], [], []
+        for i in range(len(atts) - 1):
+            a, b = atts[i], atts[i + 1]
+            if a["latitude"] and a["longitude"] and b["latitude"] and b["longitude"]:
+                leg = get_single_travel_time(
+                    a["latitude"], a["longitude"],
+                    b["latitude"], b["longitude"],
+                    request.transport_mode,
+                )
+                travel_minutes.append(leg["minutes"])
+                travel_km.append(leg["distance_km"])
+                sources.append(leg["source"])
+            else:
+                # Missing coordinates — keep a zero placeholder.
+                travel_minutes.append(0)
+                travel_km.append(None)
+                sources.append("estimate")
+
+        break_durations = day_input.break_durations or [None] * max(0, len(atts) - 1)
+        items = _compute_day_items(atts, travel_minutes, break_durations, day_input.start_time, travel_km)
+
+        # Tag each travel item with its source (google / estimate).
+        for item in items:
+            if item["type"] == "travel":
+                item["source"] = sources[item["gapIndex"]] if item["gapIndex"] < len(sources) else "estimate"
+
+        total = sum(
+            _duration_minutes(item.get("duration")) if item["type"] == "attraction"
+            else item["duration"]
+            for item in items
+        )
+
+        result_days.append({
+            "attractions":    atts,
+            "travelMinutes":  travel_minutes,
+            "travelKm":       travel_km,
+            "breakDurations": break_durations,
+            "items":          items,
+            "totalMinutes":   total,
+            "transportMode":  request.transport_mode,
+        })
+
+    return {"days": result_days}

--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.models.place import Place
-from app.schemas.itinerary import ItineraryRequest, ItineraryPlanRequest
+from app.schemas.itinerary import ItineraryRequest, ItineraryPlanRequest, OptimizedItineraryRequest
 from app.services.planner_service import (
     schedule_itinerary,
     build_daily_itinerary,
@@ -12,6 +12,14 @@ from app.services.planner_service import (
 
 router = APIRouter()
 
+
+# ---------------------------------------------------------------------------
+# OBSOLETE — POST /itinerary/plan
+# Sprint 1 single-day scheduler. Takes a flat total_minutes cap and returns
+# a list of attractions that fit within it. No travel time, no multi-day,
+# no transport mode. The frontend never calls this; kept only for reference.
+# Remove together with ItineraryRequest once /plan-optimized is live.
+# ---------------------------------------------------------------------------
 @router.post("/plan")
 async def create_plan(request: ItineraryRequest, db: Session = Depends(get_db)):
     places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
@@ -40,12 +48,15 @@ async def create_plan(request: ItineraryRequest, db: Session = Depends(get_db)):
     }
 
 
+# ---------------------------------------------------------------------------
+# TO BE REPLACED — POST /itinerary/generate
+# Sprint 2 I3 multi-day planner. Accepts place_ids in the order the frontend
+# sent them (click order) and packs them greedily into days.
+# Will be replaced by /plan-optimized once the frontend is updated.
+# Remove together with ItineraryPlanRequest at that point.
+# ---------------------------------------------------------------------------
 @router.post("/generate")
 async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depends(get_db)):
-    """
-    Build a full multi-day itinerary (clock times, travel, breaks, overflow).
-    place_ids order is preserved so the greedy packer respects the user's selection.
-    """
     places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
 
     if not places:
@@ -63,3 +74,39 @@ async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depend
         break_duration_minutes=request.break_duration_minutes,
         transport_mode=request.transport_mode,
     )
+
+
+# ---------------------------------------------------------------------------
+# CURRENT — POST /itinerary/plan-optimized
+# Backend-driven itinerary planner. Receives an unordered pool of place_ids
+# and handles ordering, time windows, per-day intensity, anchor-based routing,
+# and validation warnings. Steps added incrementally:
+#   Step 1 (now):   schema + skeleton, delegates to build_daily_itinerary
+#   Step 2 (next):  per-day time windows + per-day intensity
+#   Step 3:         validation warnings (intensity vs window, inter-day rest)
+#   Step 4:         anchor resolution (Stary Rynek default, prev/next day logic)
+#   Step 5:         route optimization (nearest-neighbor + 2-opt)
+#   Step 6:         Google finalization endpoint for accurate travel times
+# ---------------------------------------------------------------------------
+@router.post("/plan-optimized")
+async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depends(get_db)):
+    places = db.query(Place).filter(Place.id.in_(request.place_ids)).all()
+
+    if not places:
+        raise HTTPException(status_code=404, detail="No places found for given IDs")
+
+    by_id = {p.id: p for p in places}
+    attractions = [place_to_attraction(by_id[pid]) for pid in request.place_ids if pid in by_id]
+
+    result = build_daily_itinerary(
+        attractions,
+        num_days=request.num_days,
+        intensity=request.intensity,
+        start_time=request.start_time,
+        break_duration_minutes=request.break_duration_minutes,
+        transport_mode=request.transport_mode,
+    )
+
+    # warnings will be populated in Step 3
+    result["warnings"] = []
+    return result

--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -86,7 +86,7 @@ async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depend
 #   Step 2 (done):  per-day time windows + per-day intensity
 #   Step 3 (done):  validation warnings (intensity vs window, inter-day rest)
 #   Step 4 (done):  anchor resolution (Stary Rynek default, prev/next day logic)
-#   Step 5 (next):  route optimization (nearest-neighbor + 2-opt)
+#   Step 5 (done):  route optimization (nearest-neighbor + 2-opt)
 #   Step 6:         Google finalization endpoint for accurate travel times
 # ---------------------------------------------------------------------------
 @router.post("/plan-optimized")

--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -6,6 +6,7 @@ from app.schemas.itinerary import ItineraryRequest, ItineraryPlanRequest, Optimi
 from app.services.planner_service import (
     schedule_itinerary,
     build_daily_itinerary,
+    build_optimized_itinerary,
     place_to_attraction,
     rank_attractions,
 )
@@ -81,9 +82,9 @@ async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depend
 # Backend-driven itinerary planner. Receives an unordered pool of place_ids
 # and handles ordering, time windows, per-day intensity, anchor-based routing,
 # and validation warnings. Steps added incrementally:
-#   Step 1 (now):   schema + skeleton, delegates to build_daily_itinerary
-#   Step 2 (next):  per-day time windows + per-day intensity
-#   Step 3:         validation warnings (intensity vs window, inter-day rest)
+#   Step 1 (done):  schema + skeleton
+#   Step 2 (now):   per-day time windows + per-day intensity
+#   Step 3 (next):  validation warnings (intensity vs window, inter-day rest)
 #   Step 4:         anchor resolution (Stary Rynek default, prev/next day logic)
 #   Step 5:         route optimization (nearest-neighbor + 2-opt)
 #   Step 6:         Google finalization endpoint for accurate travel times
@@ -98,13 +99,21 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
     by_id = {p.id: p for p in places}
     attractions = [place_to_attraction(by_id[pid]) for pid in request.place_ids if pid in by_id]
 
-    result = build_daily_itinerary(
+    # Serialize days_config to plain dicts so planner_service has no Pydantic dependency.
+    days_config = [
+        dc.model_dump() if dc is not None else None
+        for dc in request.days_config
+    ] if request.days_config else None
+
+    result = build_optimized_itinerary(
         attractions,
         num_days=request.num_days,
-        intensity=request.intensity,
-        start_time=request.start_time,
-        break_duration_minutes=request.break_duration_minutes,
+        global_intensity=request.intensity,
+        global_start_time=request.start_time,
+        global_end_time=request.end_time,
         transport_mode=request.transport_mode,
+        break_duration_minutes=request.break_duration_minutes,
+        days_config=days_config,
     )
 
     # warnings will be populated in Step 3

--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -85,8 +85,8 @@ async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depend
 #   Step 1 (done):  schema + skeleton
 #   Step 2 (done):  per-day time windows + per-day intensity
 #   Step 3 (done):  validation warnings (intensity vs window, inter-day rest)
-#   Step 4:         anchor resolution (Stary Rynek default, prev/next day logic)
-#   Step 5:         route optimization (nearest-neighbor + 2-opt)
+#   Step 4 (done):  anchor resolution (Stary Rynek default, prev/next day logic)
+#   Step 5 (next):  route optimization (nearest-neighbor + 2-opt)
 #   Step 6:         Google finalization endpoint for accurate travel times
 # ---------------------------------------------------------------------------
 @router.post("/plan-optimized")

--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -111,6 +111,8 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
         for dc in request.days_config
     ] if request.days_config else None
 
+    pins = [p.model_dump() for p in request.pins] if request.pins else None
+
     return build_optimized_itinerary(
         attractions,
         num_days=request.num_days,
@@ -120,6 +122,7 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
         transport_mode=request.transport_mode,
         break_duration_minutes=request.break_duration_minutes,
         days_config=days_config,
+        pins=pins,
     )
 
 

--- a/travel-guide/backend/app/api/endpoints/itinerary.py
+++ b/travel-guide/backend/app/api/endpoints/itinerary.py
@@ -83,8 +83,8 @@ async def generate_itinerary(request: ItineraryPlanRequest, db: Session = Depend
 # and handles ordering, time windows, per-day intensity, anchor-based routing,
 # and validation warnings. Steps added incrementally:
 #   Step 1 (done):  schema + skeleton
-#   Step 2 (now):   per-day time windows + per-day intensity
-#   Step 3 (next):  validation warnings (intensity vs window, inter-day rest)
+#   Step 2 (done):  per-day time windows + per-day intensity
+#   Step 3 (done):  validation warnings (intensity vs window, inter-day rest)
 #   Step 4:         anchor resolution (Stary Rynek default, prev/next day logic)
 #   Step 5:         route optimization (nearest-neighbor + 2-opt)
 #   Step 6:         Google finalization endpoint for accurate travel times
@@ -105,7 +105,7 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
         for dc in request.days_config
     ] if request.days_config else None
 
-    result = build_optimized_itinerary(
+    return build_optimized_itinerary(
         attractions,
         num_days=request.num_days,
         global_intensity=request.intensity,
@@ -115,7 +115,3 @@ async def plan_optimized(request: OptimizedItineraryRequest, db: Session = Depen
         break_duration_minutes=request.break_duration_minutes,
         days_config=days_config,
     )
-
-    # warnings will be populated in Step 3
-    result["warnings"] = []
-    return result

--- a/travel-guide/backend/app/core/planning_config.py
+++ b/travel-guide/backend/app/core/planning_config.py
@@ -3,13 +3,39 @@ Planning constants — ported 1:1 from the frontend (constants.js) so the backen
 planner produces results identical to the original client-side algorithm.
 """
 
-# Itinerary intensity levels: per-day time budget and attraction cap.
-# max_attractions_per_day = None means "no cap".
+# Itinerary intensity levels.
+# max_minutes_per_day: used only by the old build_daily_itinerary (Generation 2).
+#   Generation 3 derives the time budget from end_time - start_time instead.
+# min_window_minutes / max_window_minutes: the "sensible" day-window range for
+#   this intensity, used to detect mismatches and warn the user.
+# max_attractions_per_day: None means no cap.
 INTENSITY_OPTIONS = [
-    {"key": "relaxed",  "max_minutes_per_day": 240, "max_attractions_per_day": 3},
-    {"key": "moderate", "max_minutes_per_day": 360, "max_attractions_per_day": 5},
-    {"key": "intense",  "max_minutes_per_day": 480, "max_attractions_per_day": None},
+    {
+        "key": "relaxed",
+        "max_minutes_per_day": 240,
+        "max_attractions_per_day": 3,
+        "min_window_minutes": 120,   # warn if day window < 2h with relaxed
+        "max_window_minutes": 360,   # warn if day window > 6h with relaxed
+    },
+    {
+        "key": "moderate",
+        "max_minutes_per_day": 360,
+        "max_attractions_per_day": 5,
+        "min_window_minutes": 240,   # warn if day window < 4h with moderate
+        "max_window_minutes": 600,   # warn if day window > 10h with moderate
+    },
+    {
+        "key": "intense",
+        "max_minutes_per_day": 480,
+        "max_attractions_per_day": None,
+        "min_window_minutes": 360,   # warn if day window < 6h with intense
+        "max_window_minutes": 960,   # warn if day window > 16h with intense (unrealistic)
+    },
 ]
+
+# Minimum rest between end of one day and start of the next before a warning
+# is issued. Tweakable here without touching any planner logic.
+MIN_REST_MINUTES = 600  # 10 hours
 
 # Transport modes and the average speed (km/h) used for travel-time estimates.
 TRANSPORT_OPTIONS = [
@@ -28,3 +54,8 @@ def get_intensity_config(key: str) -> dict:
 
 def get_transport_speed(mode: str) -> int:
     return next((o["speed_kmh"] for o in TRANSPORT_OPTIONS if o["key"] == mode), _DEFAULT_SPEED)
+
+
+def get_min_rest_minutes() -> int:
+    """Minimum rest between days before a warning is issued. Tune via MIN_REST_MINUTES."""
+    return MIN_REST_MINUTES

--- a/travel-guide/backend/app/schemas/itinerary.py
+++ b/travel-guide/backend/app/schemas/itinerary.py
@@ -2,41 +2,6 @@ from pydantic import BaseModel
 from typing import List, Optional
 
 
-# ---------------------------------------------------------------------------
-# OBSOLETE — used only by POST /itinerary/plan (Sprint 1, single-day only).
-# The frontend never calls /plan directly; it was only used for early testing.
-# Can be removed once /plan is dropped.
-# ---------------------------------------------------------------------------
-class ItineraryRequest(BaseModel):
-    place_ids: List[int]
-    total_minutes: int          # hard time cap computed by the frontend
-    intensity: str = "moderate"
-    start_time: str = "09:00"
-    break_duration_minutes: int = 30
-
-
-# ---------------------------------------------------------------------------
-# Used by POST /itinerary/generate (Sprint 2 I3, multi-day).
-# Preserves the place_ids order sent by the frontend — ordering was the
-# frontend's responsibility. /generate will be replaced by /plan-optimized
-# once the frontend is updated; this schema can be removed at that point.
-# ---------------------------------------------------------------------------
-class ItineraryPlanRequest(BaseModel):
-    place_ids: List[int]        # ordered by the frontend (click order)
-    num_days: int = 1
-    intensity: str = "moderate" # controls time cap + attraction count per day
-    start_time: str = "09:00"
-    break_duration_minutes: int = 30
-    transport_mode: str = "walking"
-
-
-# ---------------------------------------------------------------------------
-# Current — used by POST /itinerary/plan-optimized.
-# The backend is now responsible for ordering: it receives an unordered pool
-# of place_ids and returns an optimized route with per-day time windows,
-# per-day intensity overrides, start/end anchor support, and warnings.
-# ---------------------------------------------------------------------------
-
 class Coordinates(BaseModel):
     # A GPS point used as a day anchor (e.g. hotel, train station, map pin).
     lat: float
@@ -45,7 +10,7 @@ class Coordinates(BaseModel):
 
 class DayConfig(BaseModel):
     # Per-day overrides. Any field left null falls back to the global default
-    # on OptimizedItineraryRequest. One entry per day in days_config.
+    # on ItineraryRequest. One entry per day in days_config.
     start_time: Optional[str] = None       # e.g. "08:00" — overrides global start_time
     end_time: Optional[str] = None         # e.g. "20:00" — overrides global end_time
     intensity: Optional[str] = None        # overrides global intensity for this day only
@@ -62,12 +27,12 @@ class AttractionPin(BaseModel):
     time: Optional[str] = None  # "14:00" — if set, attraction is scheduled at this exact time
 
 
-class OptimizedItineraryRequest(BaseModel):
+class ItineraryRequest(BaseModel):
     place_ids: List[int]                   # unordered pool — backend determines visit order
     num_days: int = 1
     intensity: str = "moderate"            # global default, can be overridden per day
     start_time: str = "09:00"             # global default daily start
-    end_time: str = "17:00"               # global default daily end (replaces max_minutes)
+    end_time: str = "21:00"               # global default daily end
     transport_mode: str = "walking"        # default for all legs, per-leg override coming later
     break_duration_minutes: int = 30
     # Optional list of per-day configs. Can be null for a day to use all globals.

--- a/travel-guide/backend/app/schemas/itinerary.py
+++ b/travel-guide/backend/app/schemas/itinerary.py
@@ -53,14 +53,26 @@ class DayConfig(BaseModel):
     end_anchor: Optional[Coordinates] = None    # where the day should end
 
 
+class AttractionPin(BaseModel):
+    # Guarantees a specific attraction appears on a specific day.
+    # The attraction is removed from the free pool before the greedy packer runs,
+    # so it is always placed on the requested day regardless of time budget.
+    place_id: int
+    day: int                    # 0-indexed (0 = first day)
+    time: Optional[str] = None  # "14:00" — if set, attraction is scheduled at this exact time
+
+
 class OptimizedItineraryRequest(BaseModel):
     place_ids: List[int]                   # unordered pool — backend determines visit order
     num_days: int = 1
     intensity: str = "moderate"            # global default, can be overridden per day
     start_time: str = "09:00"             # global default daily start
-    end_time: str = "17:00"              # global default daily end (new: replaces max_minutes)
+    end_time: str = "17:00"               # global default daily end (replaces max_minutes)
     transport_mode: str = "walking"        # default for all legs, per-leg override coming later
     break_duration_minutes: int = 30
     # Optional list of per-day configs. Can be null for a day to use all globals.
     # Example: [{"start_anchor": {"lat": 52.4, "lon": 16.9}}, null, null]
     days_config: Optional[List[Optional[DayConfig]]] = None
+    # Optional list of attractions pinned to a specific day (and optionally a time).
+    # Example: [{"place_id": 5, "day": 1, "time": "14:00"}]
+    pins: Optional[List[AttractionPin]] = None

--- a/travel-guide/backend/app/schemas/itinerary.py
+++ b/travel-guide/backend/app/schemas/itinerary.py
@@ -41,6 +41,9 @@ class ItineraryRequest(BaseModel):
     # Optional list of attractions pinned to a specific day (and optionally a time).
     # Example: [{"place_id": 5, "day": 1, "time": "14:00"}]
     pins: Optional[List[AttractionPin]] = None
+    # User's preferred categories — attractions in these categories are packed first
+    # so they survive the overflow cut when the time budget is tight.
+    selected_categories: Optional[List[str]] = None
 
 
 # ---------------------------------------------------------------------------

--- a/travel-guide/backend/app/schemas/itinerary.py
+++ b/travel-guide/backend/app/schemas/itinerary.py
@@ -1,19 +1,66 @@
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
+
+# ---------------------------------------------------------------------------
+# OBSOLETE — used only by POST /itinerary/plan (Sprint 1, single-day only).
+# The frontend never calls /plan directly; it was only used for early testing.
+# Can be removed once /plan is dropped.
+# ---------------------------------------------------------------------------
 class ItineraryRequest(BaseModel):
     place_ids: List[int]
-    total_minutes: int
+    total_minutes: int          # hard time cap computed by the frontend
     intensity: str = "moderate"
     start_time: str = "09:00"
     break_duration_minutes: int = 30
 
 
+# ---------------------------------------------------------------------------
+# Used by POST /itinerary/generate (Sprint 2 I3, multi-day).
+# Preserves the place_ids order sent by the frontend — ordering was the
+# frontend's responsibility. /generate will be replaced by /plan-optimized
+# once the frontend is updated; this schema can be removed at that point.
+# ---------------------------------------------------------------------------
 class ItineraryPlanRequest(BaseModel):
-    """Request for the multi-day planner. place_ids order is preserved."""
-    place_ids: List[int]
+    place_ids: List[int]        # ordered by the frontend (click order)
     num_days: int = 1
-    intensity: str = "moderate"
+    intensity: str = "moderate" # controls time cap + attraction count per day
     start_time: str = "09:00"
     break_duration_minutes: int = 30
     transport_mode: str = "walking"
+
+
+# ---------------------------------------------------------------------------
+# Current — used by POST /itinerary/plan-optimized.
+# The backend is now responsible for ordering: it receives an unordered pool
+# of place_ids and returns an optimized route with per-day time windows,
+# per-day intensity overrides, start/end anchor support, and warnings.
+# ---------------------------------------------------------------------------
+
+class Coordinates(BaseModel):
+    # A GPS point used as a day anchor (e.g. hotel, train station, map pin).
+    lat: float
+    lon: float
+
+
+class DayConfig(BaseModel):
+    # Per-day overrides. Any field left null falls back to the global default
+    # on OptimizedItineraryRequest. One entry per day in days_config.
+    start_time: Optional[str] = None       # e.g. "08:00" — overrides global start_time
+    end_time: Optional[str] = None         # e.g. "20:00" — overrides global end_time
+    intensity: Optional[str] = None        # overrides global intensity for this day only
+    start_anchor: Optional[Coordinates] = None  # where the day should start (hotel, pin…)
+    end_anchor: Optional[Coordinates] = None    # where the day should end
+
+
+class OptimizedItineraryRequest(BaseModel):
+    place_ids: List[int]                   # unordered pool — backend determines visit order
+    num_days: int = 1
+    intensity: str = "moderate"            # global default, can be overridden per day
+    start_time: str = "09:00"             # global default daily start
+    end_time: str = "17:00"              # global default daily end (new: replaces max_minutes)
+    transport_mode: str = "walking"        # default for all legs, per-leg override coming later
+    break_duration_minutes: int = 30
+    # Optional list of per-day configs. Can be null for a day to use all globals.
+    # Example: [{"start_anchor": {"lat": 52.4, "lon": 16.9}}, null, null]
+    days_config: Optional[List[Optional[DayConfig]]] = None

--- a/travel-guide/backend/app/schemas/itinerary.py
+++ b/travel-guide/backend/app/schemas/itinerary.py
@@ -76,3 +76,22 @@ class OptimizedItineraryRequest(BaseModel):
     # Optional list of attractions pinned to a specific day (and optionally a time).
     # Example: [{"place_id": 5, "day": 1, "time": "14:00"}]
     pins: Optional[List[AttractionPin]] = None
+
+
+# ---------------------------------------------------------------------------
+# Google finalization — POST /itinerary/finalize
+# Called once the user is happy with the ordering. Replaces haversine estimates
+# with real Google Distance Matrix times for the selected transport mode.
+# ---------------------------------------------------------------------------
+
+class FinalizeDayInput(BaseModel):
+    # One day's worth of ordered place_ids as confirmed by the user.
+    place_ids: List[int]
+    start_time: str = "09:00"
+    # Per-gap break durations (same length as place_ids - 1). None = no break.
+    break_durations: Optional[List[Optional[int]]] = None
+
+
+class FinalizeRequest(BaseModel):
+    days: List[FinalizeDayInput]
+    transport_mode: str = "walking"  # applied to all legs

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -443,6 +443,77 @@ def _check_inter_day_rest(day_index: int, days: list[dict], resolved: list[dict]
     return None
 
 
+# Default city-centre anchor used when no explicit start/end is provided.
+_CITY_CENTRE = {"latitude": 52.40825, "longitude": 16.93364}  # Stary Rynek
+
+
+def _resolve_anchors(
+    num_days: int,
+    days_config: list | None,
+    days: list[dict],
+) -> list[dict]:
+    """
+    Determine the start and end anchor for each day following these rules:
+
+    Start anchor priority (per day):
+      1. Explicit start_anchor in days_config for this day
+      2. Day 1 → city centre (Stary Rynek)
+         Day 2+ → previous day's explicit end_anchor if set,
+                  otherwise last attraction of the previous day
+
+    End anchor priority (per day):
+      1. Explicit end_anchor in days_config for this day
+      2. Last day → city centre (Stary Rynek)
+         Middle days → next day's explicit start_anchor if set,
+                       otherwise None (optimizer is free to end anywhere)
+
+    Returns a list of {"start": dict|None, "end": dict|None} per day.
+    The dicts have "latitude"/"longitude" keys so _haversine_* functions work directly.
+    """
+    def _cfg(day_index):
+        if days_config and day_index < len(days_config):
+            return days_config[day_index] or {}
+        return {}
+
+    def _anchor_coords(anchor_dict):
+        if not anchor_dict:
+            return None
+        return {"latitude": anchor_dict["lat"], "longitude": anchor_dict["lon"]}
+
+    anchors = []
+    for i in range(num_days):
+        cfg      = _cfg(i)
+        cfg_next = _cfg(i + 1) if i < num_days - 1 else {}
+
+        # --- start anchor ---
+        if cfg.get("start_anchor"):
+            start = _anchor_coords(cfg["start_anchor"])
+        elif i == 0:
+            start = _CITY_CENTRE
+        else:
+            prev_cfg = _cfg(i - 1)
+            if prev_cfg.get("end_anchor"):
+                start = _anchor_coords(prev_cfg["end_anchor"])
+            else:
+                prev_attractions = days[i - 1]["attractions"]
+                start = prev_attractions[-1] if prev_attractions else _CITY_CENTRE
+
+        # --- end anchor ---
+        if cfg.get("end_anchor"):
+            end = _anchor_coords(cfg["end_anchor"])
+        elif i == num_days - 1:
+            end = _CITY_CENTRE
+        else:
+            if cfg_next.get("start_anchor"):
+                end = _anchor_coords(cfg_next["start_anchor"])
+            else:
+                end = None  # optimizer is free
+
+        anchors.append({"start": start, "end": end})
+
+    return anchors
+
+
 def _resolve_day_settings(
     day_index: int,
     global_start: str,
@@ -505,8 +576,8 @@ def build_optimized_itinerary(
     Steps still to be added (see endpoints/itinerary.py for the full roadmap):
     - Pinned attractions: pre-assign specific place_ids to specific days before
       the greedy loop runs (place_ids in pins are removed from the free pool).
-    - Anchor resolution: Stary Rynek default, prev/next day handoff logic.
-    - Route optimisation: nearest-neighbour + 2-opt within each day.
+    - Route optimisation: nearest-neighbour + 2-opt within each day,
+      consuming startAnchor/endAnchor already resolved on each day dict.
     """
     speed    = get_transport_speed(transport_mode)
     resolved = [
@@ -567,6 +638,16 @@ def build_optimized_itinerary(
             day["totalMinutes"] += duration
         else:
             overflow.append(attraction)
+
+    # Resolve anchors after packing — start anchors for day 2+ may depend on
+    # the last attraction placed in the previous day.
+    anchors = _resolve_anchors(num_days, days_config, days)
+    for i, day in enumerate(days):
+        day["startAnchor"] = anchors[i]["start"]
+        day["endAnchor"]   = anchors[i]["end"]
+
+    # TODO (route optimisation step): re-order day["attractions"] here using
+    # anchors[i]["start"] and anchors[i]["end"] before computing items.
 
     for i, day in enumerate(days):
         day["items"] = _compute_day_items(

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -1,27 +1,13 @@
 """
 planner_service.py — all itinerary scheduling logic.
 
-There are two generations of planners in this file:
+  build_itinerary  →  POST /itinerary/plan
+    Backend-driven multi-day planner: per-day time windows, per-day intensity
+    overrides, start/end anchor-based routing, nearest-neighbour + 2-opt route
+    optimisation, pinned attractions, and validation warnings.
 
-  GENERATION 1 (Sprint 1 / obsolete)
-    schedule_itinerary  →  used by POST /itinerary/plan
-    Simple single-day greedy scheduler. No travel time, no multi-day.
-    Will be removed when /plan is dropped.
-
-  GENERATION 2 (Sprint 2 I3 / to be replaced)
-    build_daily_itinerary  →  used by POST /itinerary/generate
-    Multi-day greedy packer ported 1:1 from the frontend (utils.js).
-    Respects the place_ids order sent by the client.
-    Will be removed when the frontend switches to /plan-optimized.
-
-  GENERATION 3 (current / active development)
-    build_optimized_itinerary  →  used by POST /itinerary/plan-optimized
-    Same greedy packer but backend-driven: per-day time windows, per-day
-    intensity overrides, anchor-based routing, and route optimisation.
-    Steps being added incrementally (see endpoints/itinerary.py for the list).
-
-All three generations share the same set of private helpers (_haversine_km,
-_compute_day_items, etc.) defined below.
+Private helpers (_haversine_km, _compute_day_items, etc.) are used by both
+build_itinerary and the /finalize endpoint.
 """
 
 import math
@@ -47,102 +33,7 @@ def _minutes_to_time(total: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Generation 1 helpers — only used by schedule_itinerary / POST /plan
-# ---------------------------------------------------------------------------
-
-def _parse_duration(duration: str) -> int:
-    # Parses "Xh Ymin" / "Xh" / "Ymin" → minutes. Defaults to 60 if empty.
-    # Used only by the old schedule_itinerary; Generation 2+ uses _duration_minutes.
-    if not duration:
-        return 60
-    if "h" in duration and "min" in duration:
-        parts = duration.split("h")
-        return int(parts[0].strip()) * 60 + int(parts[1].replace("min", "").strip())
-    if "h" in duration:
-        return int(duration.split("h")[0].strip()) * 60
-    if "min" in duration:
-        return int(duration.split("min")[0].strip())
-    return 60
-
-
-# ---------------------------------------------------------------------------
-# GENERATION 1 — obsolete, kept until POST /itinerary/plan is removed
-# ---------------------------------------------------------------------------
-
-def schedule_itinerary(places, total_minutes, start_time="09:00", break_duration_minutes=30, intensity="moderate"):
-    """
-    Single-day greedy scheduler (Sprint 1).
-    Iterates places in the given order and stops when total_minutes is exhausted.
-    No travel time between places. Inserts breaks only in relaxed mode.
-    """
-    plan = []
-    elapsed = 0
-    current = _time_to_minutes(start_time)
-    is_relaxed = intensity == "relaxed"
-
-    for place in places:
-        duration_val = _parse_duration(place.duration)
-
-        if is_relaxed and plan:
-            current += break_duration_minutes
-            elapsed += break_duration_minutes
-            plan.append({
-                "type": "break",
-                "duration": break_duration_minutes,
-                "start_at": _minutes_to_time(current - break_duration_minutes),
-                "end_at": _minutes_to_time(current),
-            })
-
-        if elapsed + duration_val > total_minutes:
-            break
-
-        start_at = _minutes_to_time(current)
-        current += duration_val
-        elapsed += duration_val
-
-        plan.append({
-            "type": "attraction",
-            "id": place.id,
-            "name": place.name_en or place.name_pl,
-            "duration": place.duration,
-            "start_at": start_at,
-            "end_at": _minutes_to_time(current),
-        })
-
-    if not plan and places:
-        for place in places:
-            duration_val = _parse_duration(place.duration)
-            if duration_val <= total_minutes:
-                start_at = _minutes_to_time(current)
-                current += duration_val
-                plan.append({
-                    "type": "attraction",
-                    "id": place.id,
-                    "name": place.name_en or place.name_pl,
-                    "duration": place.duration,
-                    "start_at": start_at,
-                    "end_at": _minutes_to_time(current),
-                })
-                break
-
-    return plan
-  
-def rank_attractions(places, selected_categories: list) -> list:
-    if not selected_categories:
-        return places
-
-    ranked_places = []
-    for place in places:
-        weight = 0
-        if place.category in selected_categories:
-            weight = 100
-        ranked_places.append((weight, place))
-
-    ranked_places.sort(key=lambda x: x[0], reverse=True)
-    return [p[1] for p in ranked_places]
-
-# ---------------------------------------------------------------------------
-# Shared helpers — used by Generation 2 and Generation 3
+# Shared helpers
 # ---------------------------------------------------------------------------
 
 def _duration_minutes(duration: str | None) -> int:
@@ -320,88 +211,7 @@ def place_to_attraction(place) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# GENERATION 2 — to be removed when /itinerary/generate is retired
-# ---------------------------------------------------------------------------
-
-def build_daily_itinerary(
-    attractions: list[dict],
-    num_days: int,
-    intensity: str = "moderate",
-    start_time: str = "09:00",
-    break_duration_minutes: int = 30,
-    transport_mode: str = "walking",
-) -> dict:
-    """
-    Multi-day greedy packer ported 1:1 from the frontend buildDailyItinerary (utils.js).
-    Respects the order of attractions as received — ordering is the caller's responsibility.
-    Time budget per day comes from intensity config (max_minutes_per_day).
-    Used by POST /itinerary/generate; will be retired when /plan-optimized is live.
-    """
-    config          = get_intensity_config(intensity)
-    max_minutes     = config["max_minutes_per_day"]
-    max_attractions = config["max_attractions_per_day"]
-    is_relaxed      = intensity == "relaxed"
-    speed           = get_transport_speed(transport_mode)
-
-    days = [
-        {
-            "attractions":    [],
-            "travelMinutes":  [],
-            "travelKm":       [],
-            "breakDurations": [],
-            "items":          [],
-            "totalMinutes":   0,
-        }
-        for _ in range(num_days)
-    ]
-    overflow = []
-
-    for attraction in attractions:
-        duration = _duration_minutes(attraction.get("duration"))
-
-        # Try to fit into the first day that has room (time + count budget).
-        day_index = -1
-        for idx, day in enumerate(days):
-            last           = day["attractions"][-1] if day["attractions"] else None
-            travel         = _haversine_minutes(last, attraction, speed) if last else 0
-            break_overhead = break_duration_minutes if (is_relaxed and day["attractions"]) else 0
-            fits_time      = day["totalMinutes"] + travel + break_overhead + duration <= max_minutes
-            fits_count     = max_attractions is None or len(day["attractions"]) < max_attractions
-            if fits_time and fits_count:
-                day_index = idx
-                break
-
-        if day_index != -1:
-            day = days[day_index]
-            if day["attractions"]:
-                last   = day["attractions"][-1]
-                travel = _haversine_minutes(last, attraction, speed)
-                km     = _haversine_km(last, attraction)
-                day["travelMinutes"].append(travel)
-                day["travelKm"].append(_js_round2(km) if km is not None else None)
-                day["totalMinutes"] += travel
-                day["breakDurations"].append(break_duration_minutes if is_relaxed else None)
-                if is_relaxed:
-                    day["totalMinutes"] += break_duration_minutes
-            day["attractions"].append(attraction)
-            day["totalMinutes"] += duration
-        else:
-            overflow.append(attraction)
-
-    for day in days:
-        day["items"] = _compute_day_items(
-            day["attractions"],
-            day["travelMinutes"],
-            day["breakDurations"],
-            start_time,
-            day["travelKm"],
-        )
-
-    return {"days": days, "overflow": overflow}
-
-
-# ---------------------------------------------------------------------------
-# GENERATION 3 helpers
+# Planner helpers
 # ---------------------------------------------------------------------------
 
 def _check_intensity_window(day_index: int, resolved: list[dict]) -> dict | None:
@@ -706,28 +516,27 @@ def _resolve_day_settings(
 
 
 # ---------------------------------------------------------------------------
-# GENERATION 3 — active, used by POST /itinerary/plan-optimized
+# Main planner — POST /itinerary/plan
 # ---------------------------------------------------------------------------
 
-def build_optimized_itinerary(
+def build_itinerary(
     attractions: list[dict],
     num_days: int,
     global_intensity: str = "moderate",
     global_start_time: str = "09:00",
-    global_end_time: str = "17:00",
+    global_end_time: str = "21:00",
     transport_mode: str = "walking",
     break_duration_minutes: int = 30,
     days_config: list | None = None,
     pins: list | None = None,
 ) -> dict:
     """
-    Greedy packer with per-day time windows and per-day intensity overrides.
+    Greedy multi-day packer with route optimisation and per-day configuration.
 
-    Key differences from build_daily_itinerary (Gen 2):
-    - Time budget per day = end_time - start_time, NOT intensity.max_minutes_per_day.
-      Intensity only controls the attraction count cap for each day.
-    - Each day in the response includes startTime, endTime, intensity fields.
-    - days_config allows overriding any of these per day.
+    Time budget per day = end_time - start_time.
+    Intensity controls the attraction count cap (not time budget).
+    Each day in the response includes startTime, endTime, intensity fields.
+    days_config allows overriding any of these per day.
 
     Steps still to be added (see endpoints/itinerary.py for the full roadmap):
     - Pinned attractions: pre-assign specific place_ids to specific days before

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -447,6 +447,118 @@ def _check_inter_day_rest(day_index: int, days: list[dict], resolved: list[dict]
 _CITY_CENTRE = {"latitude": 52.40825, "longitude": 16.93364}  # Stary Rynek
 
 
+def _km_cached(a, b, cache: dict | None) -> float | None:
+    """
+    Return km between two points, using the pre-built distance cache when both
+    points carry an 'id' key (i.e. they are attraction dicts, not raw anchors).
+    Falls back to haversine for anchor points that have no id.
+    """
+    if cache is not None and a and b:
+        a_id = a.get("id")
+        b_id = b.get("id")
+        if a_id is not None and b_id is not None:
+            return cache.get((a_id, b_id))
+    return _haversine_km(a, b)
+
+
+def _route_distance(attractions: list[dict], start_anchor, end_anchor, speed: int,
+                    cache: dict | None = None) -> int:
+    """
+    Total estimated travel time for a route: start_anchor → attractions → end_anchor.
+    end_anchor may be None (open end), in which case only the inter-attraction legs count.
+    Used as the objective function for 2-opt.
+    """
+    total = 0
+    prev  = start_anchor
+    for a in attractions:
+        km     = _km_cached(prev, a, cache)
+        total += int(math.ceil((km / speed) * 60 / 5) * 5) if km else 0
+        prev   = a
+    if end_anchor:
+        km     = _km_cached(prev, end_anchor, cache)
+        total += int(math.ceil((km / speed) * 60 / 5) * 5) if km else 0
+    return total
+
+
+def _nearest_neighbour(
+    attractions: list[dict],
+    start_anchor,
+    cache: dict | None = None,
+) -> list[dict]:
+    """
+    Greedy nearest-neighbour ordering starting from start_anchor.
+    At each step, pick the unvisited attraction closest (in km) to the current
+    position. Speed is not needed here — all legs share the same speed so
+    closest km == closest time. Uses dist_cache for attraction-to-attraction lookups.
+    """
+    if not attractions:
+        return []
+
+    unvisited = list(attractions)
+    ordered   = []
+    current   = start_anchor
+
+    while unvisited:
+        nearest = min(unvisited, key=lambda a: (
+            _km_cached(current, a, cache) or _haversine_km(current, a) or 0
+        ))
+        ordered.append(nearest)
+        unvisited.remove(nearest)
+        current = nearest
+
+    return ordered
+
+
+def _two_opt(
+    attractions: list[dict],
+    start_anchor,
+    end_anchor,
+    speed: int,
+    cache: dict | None = None,
+) -> list[dict]:
+    """
+    Improve a route by trying all pairs of edge swaps (2-opt).
+    Reverses the sub-sequence between indices i and k whenever doing so reduces
+    the total route distance. Stops when no improving swap is found.
+    The start_anchor and end_anchor are included in the distance objective so the
+    route stays anchored to them even after swaps.
+    """
+    best     = list(attractions)
+    improved = True
+    while improved:
+        improved = False
+        best_dist = _route_distance(best, start_anchor, end_anchor, speed, cache)
+        for i in range(len(best) - 1):
+            for k in range(i + 1, len(best)):
+                candidate      = best[:i] + best[i:k + 1][::-1] + best[k + 1:]
+                candidate_dist = _route_distance(candidate, start_anchor, end_anchor, speed, cache)
+                if candidate_dist < best_dist:
+                    best      = candidate
+                    best_dist = candidate_dist
+                    improved  = True
+
+
+    return best
+
+
+def _optimise_day_order(
+    attractions: list[dict],
+    start_anchor,
+    end_anchor,
+    speed: int,
+    cache: dict | None = None,
+) -> list[dict]:
+    """
+    Return attractions in the optimised visiting order for one day.
+    Runs nearest-neighbour first (fast, good starting point), then 2-opt
+    (removes route crossings). Both respect the start and end anchors.
+    """
+    if len(attractions) <= 1:
+        return attractions
+    ordered = _nearest_neighbour(attractions, start_anchor, cache)
+    return _two_opt(ordered, start_anchor, end_anchor, speed, cache)
+
+
 def _resolve_anchors(
     num_days: int,
     days_config: list | None,
@@ -579,7 +691,20 @@ def build_optimized_itinerary(
     - Route optimisation: nearest-neighbour + 2-opt within each day,
       consuming startAnchor/endAnchor already resolved on each day dict.
     """
-    speed    = get_transport_speed(transport_mode)
+    speed = get_transport_speed(transport_mode)
+
+    # Pre-build pairwise haversine distance matrix (km) for all attractions.
+    # Keyed by (id_a, id_b); symmetric so both directions are stored.
+    # The optimizer functions look up from this cache instead of recomputing,
+    # which matters most in the 2-opt inner loop (O(N²) evaluations per pass).
+    dist_cache: dict = {}
+    for a in attractions:
+        for b in attractions:
+            if a["id"] != b["id"] and (a["id"], b["id"]) not in dist_cache:
+                km = _haversine_km(a, b)
+                dist_cache[(a["id"], b["id"])] = km
+                dist_cache[(b["id"], a["id"])] = km
+
     resolved = [
         _resolve_day_settings(i, global_start_time, global_end_time, global_intensity, days_config)
         for i in range(num_days)
@@ -646,8 +771,40 @@ def build_optimized_itinerary(
         day["startAnchor"] = anchors[i]["start"]
         day["endAnchor"]   = anchors[i]["end"]
 
-    # TODO (route optimisation step): re-order day["attractions"] here using
-    # anchors[i]["start"] and anchors[i]["end"] before computing items.
+    # Re-order each day's attractions using nearest-neighbour + 2-opt, then
+    # recompute travel/break/total from the new order.
+    for i, day in enumerate(days):
+        if len(day["attractions"]) > 1:
+            day["attractions"] = _optimise_day_order(
+                day["attractions"],
+                anchors[i]["start"],
+                anchors[i]["end"],
+                speed,
+                dist_cache,
+            )
+
+        # Recompute travel and break arrays from the optimised order.
+        # Uses dist_cache for attraction-to-attraction legs.
+        is_relaxed = resolved[i]["intensity"] == "relaxed"
+        atts       = day["attractions"]
+        t_mins, t_km, b_durs, total = [], [], [], 0
+
+        for j, attr in enumerate(atts):
+            total += _duration_minutes(attr.get("duration"))
+            if j < len(atts) - 1:
+                km     = _km_cached(attr, atts[j + 1], dist_cache)
+                travel = int(math.ceil((km / speed) * 60 / 5) * 5) if km else 0
+                t_mins.append(travel)
+                t_km.append(_js_round2(km) if km is not None else None)
+                total += travel
+                b_durs.append(break_duration_minutes if is_relaxed else None)
+                if is_relaxed:
+                    total += break_duration_minutes
+
+        day["travelMinutes"]  = t_mins
+        day["travelKm"]       = t_km
+        day["breakDurations"] = b_durs
+        day["totalMinutes"]   = total
 
     for i, day in enumerate(days):
         day["items"] = _compute_day_items(

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -529,6 +529,7 @@ def build_itinerary(
     break_duration_minutes: int = 30,
     days_config: list | None = None,
     pins: list | None = None,
+    selected_categories: list | None = None,
 ) -> dict:
     """
     Greedy multi-day packer with route optimisation and per-day configuration.
@@ -608,7 +609,13 @@ def build_itinerary(
             pinned_ids.add(place_id)
 
     # Free pool: all attractions not already pinned to a specific day.
-    free_attractions = [a for a in attractions if a["id"] not in pinned_ids]
+    # Sort preferred categories first so they win the overflow cut when the
+    # time budget is tight — non-preferred attractions are the ones left out.
+    preferred = set(selected_categories) if selected_categories else set()
+    free_attractions = sorted(
+        [a for a in attractions if a["id"] not in pinned_ids],
+        key=lambda a: 0 if a.get("category") in preferred else 1,
+    )
 
     for attraction in free_attractions:
         duration = _duration_minutes(attraction.get("duration"))

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -27,7 +27,7 @@ _compute_day_items, etc.) defined below.
 import math
 import re
 
-from app.core.planning_config import get_intensity_config, get_transport_speed
+from app.core.planning_config import get_intensity_config, get_transport_speed, get_min_rest_minutes
 
 
 # ---------------------------------------------------------------------------
@@ -361,6 +361,88 @@ def build_daily_itinerary(
 # GENERATION 3 helpers
 # ---------------------------------------------------------------------------
 
+def _check_intensity_window(day_index: int, resolved: list[dict]) -> dict | None:
+    """
+    Warn if the day's time window is too short or too long for its intensity.
+    E.g. a 10h window with relaxed intensity (designed for ~2–6h) is a mismatch.
+    Returns a warning dict or None if everything looks fine.
+    """
+    r           = resolved[day_index]
+    config      = get_intensity_config(r["intensity"])
+    window      = r["max_minutes"]
+    min_window  = config["min_window_minutes"]
+    max_window  = config["max_window_minutes"]
+
+    if window < min_window:
+        return {
+            "type":    "intensity_mismatch",
+            "day":     day_index + 1,  # 1-indexed for display
+            "message": (
+                f"Day {day_index + 1}: {r['intensity']} intensity expects at least "
+                f"{min_window // 60}h but the window is only {window // 60}h "
+                f"{window % 60:02d}min ({r['start_time']}–{r['end_time']})."
+            ),
+        }
+    if window > max_window:
+        return {
+            "type":    "intensity_mismatch",
+            "day":     day_index + 1,
+            "message": (
+                f"Day {day_index + 1}: {r['intensity']} intensity is designed for up to "
+                f"{max_window // 60}h but the window is {window // 60}h "
+                f"{window % 60:02d}min ({r['start_time']}–{r['end_time']}). "
+                f"Consider switching to a more intense setting."
+            ),
+        }
+    return None
+
+
+def _check_inter_day_rest(day_index: int, days: list[dict], resolved: list[dict]) -> dict | None:
+    """
+    Warn if there is less than MIN_REST_MINUTES of rest between the actual end
+    of day N and the configured start of day N+1.
+    Rest is computed across the midnight boundary (day N ends at e.g. 20:00,
+    day N+1 starts at 09:00 → 13h rest).
+    """
+    if day_index >= len(days) - 1:
+        return None  # no next day to compare against
+
+    day = days[day_index]
+
+    # Actual end: last item's end_at, or the configured end_time if day is empty.
+    if day["items"]:
+        actual_end_str = day["items"][-1]["end_at"]
+    else:
+        actual_end_str = resolved[day_index]["end_time"]
+
+    next_start_str = resolved[day_index + 1]["start_time"]
+
+    end_min   = _time_to_minutes(actual_end_str)
+    start_min = _time_to_minutes(next_start_str)
+
+    # Rest spans midnight: add 24h if next start is earlier in the clock than current end.
+    rest_minutes = start_min - end_min
+    if rest_minutes < 0:
+        rest_minutes += 24 * 60
+
+    min_rest = get_min_rest_minutes()
+    if rest_minutes < min_rest:
+        rest_h   = rest_minutes // 60
+        rest_min = rest_minutes % 60
+        return {
+            "type":          "insufficient_rest",
+            "between_days":  [day_index + 1, day_index + 2],  # 1-indexed
+            "rest_hours":    round(rest_minutes / 60, 1),
+            "message": (
+                f"Only {rest_h}h {rest_min:02d}min of rest between day {day_index + 1} "
+                f"(ends {actual_end_str}) and day {day_index + 2} "
+                f"(starts {next_start_str}). "
+                f"Recommended minimum is {min_rest // 60}h."
+            ),
+        }
+    return None
+
+
 def _resolve_day_settings(
     day_index: int,
     global_start: str,
@@ -495,4 +577,14 @@ def build_optimized_itinerary(
             day["travelKm"],
         )
 
-    return {"days": days, "overflow": overflow}
+    # Collect warnings after items are built (rest check needs actual end times).
+    warnings = []
+    for i in range(num_days):
+        w = _check_intensity_window(i, resolved)
+        if w:
+            warnings.append(w)
+        w = _check_inter_day_rest(i, days, resolved)
+        if w:
+            warnings.append(w)
+
+    return {"days": days, "overflow": overflow, "warnings": warnings}

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -1,19 +1,58 @@
+"""
+planner_service.py — all itinerary scheduling logic.
+
+There are two generations of planners in this file:
+
+  GENERATION 1 (Sprint 1 / obsolete)
+    schedule_itinerary  →  used by POST /itinerary/plan
+    Simple single-day greedy scheduler. No travel time, no multi-day.
+    Will be removed when /plan is dropped.
+
+  GENERATION 2 (Sprint 2 I3 / to be replaced)
+    build_daily_itinerary  →  used by POST /itinerary/generate
+    Multi-day greedy packer ported 1:1 from the frontend (utils.js).
+    Respects the place_ids order sent by the client.
+    Will be removed when the frontend switches to /plan-optimized.
+
+  GENERATION 3 (current / active development)
+    build_optimized_itinerary  →  used by POST /itinerary/plan-optimized
+    Same greedy packer but backend-driven: per-day time windows, per-day
+    intensity overrides, anchor-based routing, and route optimisation.
+    Steps being added incrementally (see endpoints/itinerary.py for the list).
+
+All three generations share the same set of private helpers (_haversine_km,
+_compute_day_items, etc.) defined below.
+"""
+
 import math
 import re
 
 from app.core.planning_config import get_intensity_config, get_transport_speed
 
 
+# ---------------------------------------------------------------------------
+# Time helpers — used by all three generations
+# ---------------------------------------------------------------------------
+
 def _time_to_minutes(t: str) -> int:
+    # "HH:MM" → total minutes from midnight. e.g. "09:30" → 570
     h, m = map(int, t.split(":"))
     return h * 60 + m
 
 def _minutes_to_time(total: int) -> str:
+    # Total minutes from midnight → "HH:MM". Wraps at 24h.
     h = (total // 60) % 24
     m = total % 60
     return f"{h:02d}:{m:02d}"
 
+
+# ---------------------------------------------------------------------------
+# Generation 1 helpers — only used by schedule_itinerary / POST /plan
+# ---------------------------------------------------------------------------
+
 def _parse_duration(duration: str) -> int:
+    # Parses "Xh Ymin" / "Xh" / "Ymin" → minutes. Defaults to 60 if empty.
+    # Used only by the old schedule_itinerary; Generation 2+ uses _duration_minutes.
     if not duration:
         return 60
     if "h" in duration and "min" in duration:
@@ -25,7 +64,17 @@ def _parse_duration(duration: str) -> int:
         return int(duration.split("min")[0].strip())
     return 60
 
+
+# ---------------------------------------------------------------------------
+# GENERATION 1 — obsolete, kept until POST /itinerary/plan is removed
+# ---------------------------------------------------------------------------
+
 def schedule_itinerary(places, total_minutes, start_time="09:00", break_duration_minutes=30, intensity="moderate"):
+    """
+    Single-day greedy scheduler (Sprint 1).
+    Iterates places in the given order and stops when total_minutes is exhausted.
+    No travel time between places. Inserts breaks only in relaxed mode.
+    """
     plan = []
     elapsed = 0
     current = _time_to_minutes(start_time)
@@ -93,21 +142,20 @@ def rank_attractions(places, selected_categories: list) -> list:
     return [p[1] for p in ranked_places]
 
 # ---------------------------------------------------------------------------
-# Multi-day planner
-#
-# Ported 1:1 from the frontend (utils.js -> buildDailyItinerary) so the backend
-# produces results identical to the original client-side algorithm. Output uses
-# the same field names as the frontend `days` structure (camelCase) so the
-# frontend can swap its local call for a fetch with no shape changes.
+# Shared helpers — used by Generation 2 and Generation 3
 # ---------------------------------------------------------------------------
 
 def _duration_minutes(duration: str | None) -> int:
-    """Parse 'Xh Ymin' / 'Xh' / 'Y min' into minutes. Empty -> 0 (matches JS)."""
+    """
+    Parse 'Xh Ymin' / 'Xh' / 'Ymin' into minutes. Returns 0 if empty.
+    Differs from _parse_duration (Gen 1) which defaults to 60 — this matches
+    the JS behaviour (parseDurationToMinutes returns 0 for empty).
+    """
     if not duration:
         return 0
     total = 0
     hours = re.search(r"(\d+)\s*h", duration)
-    mins = re.search(r"(\d+)\s*min", duration)
+    mins  = re.search(r"(\d+)\s*min", duration)
     if hours:
         total += int(hours.group(1)) * 60
     if mins:
@@ -116,11 +164,15 @@ def _duration_minutes(duration: str | None) -> int:
 
 
 def _js_round2(value: float) -> float:
-    """Match JS Math.round(value * 100) / 100 (round half up)."""
+    """Round to 2 decimal places using JS semantics (round half up, not banker's rounding)."""
     return math.floor(value * 100 + 0.5) / 100
 
 
 def _haversine_km(a: dict | None, b: dict | None) -> float | None:
+    """
+    Straight-line distance in km between two attraction dicts (need latitude/longitude keys).
+    Returns None if either point is missing coordinates — callers treat None as 0 travel time.
+    """
     if not a or not b:
         return None
     if a.get("latitude") is None or a.get("longitude") is None:
@@ -128,16 +180,19 @@ def _haversine_km(a: dict | None, b: dict | None) -> float | None:
     if b.get("latitude") is None or b.get("longitude") is None:
         return None
     R = 6371
-    lat1 = math.radians(a["latitude"])
-    lat2 = math.radians(b["latitude"])
-    d_lat = math.radians(b["latitude"] - a["latitude"])
+    lat1  = math.radians(a["latitude"])
+    lat2  = math.radians(b["latitude"])
+    d_lat = math.radians(b["latitude"]  - a["latitude"])
     d_lon = math.radians(b["longitude"] - a["longitude"])
     h = math.sin(d_lat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(d_lon / 2) ** 2
     return R * 2 * math.atan2(math.sqrt(h), math.sqrt(1 - h))
 
 
 def _haversine_minutes(a: dict | None, b: dict | None, speed_kmh: int = 5) -> int:
-    """Straight-line travel minutes, rounded UP to the nearest 5 (matches JS)."""
+    """
+    Estimated travel time in minutes between two points, rounded UP to the nearest 5.
+    Used for budget checks and route optimisation (not for display — Google times are used there).
+    """
     km = _haversine_km(a, b)
     if km is None:
         return 0
@@ -146,9 +201,13 @@ def _haversine_minutes(a: dict | None, b: dict | None, speed_kmh: int = 5) -> in
 
 
 def _recalculate_item_times(items: list[dict], start_time: str) -> list[dict]:
-    """Assign sequential start_at/end_at clock times to every item in a day."""
+    """
+    Walk through a flat list of attraction/travel/break items and assign
+    sequential start_at / end_at clock strings to each one.
+    Each item's duration drives the clock forward.
+    """
     current = _time_to_minutes(start_time)
-    result = []
+    result  = []
     for item in items:
         duration = (
             _duration_minutes(item.get("duration"))
@@ -157,54 +216,69 @@ def _recalculate_item_times(items: list[dict], start_time: str) -> list[dict]:
         )
         start_at = _minutes_to_time(current)
         current += duration
-        end_at = _minutes_to_time(current)
+        end_at   = _minutes_to_time(current)
         result.append({**item, "start_at": start_at, "end_at": end_at})
     return result
 
 
 def _compute_day_items(attractions, travel_minutes, break_durations, start_time, travel_km=None):
-    """Build the flat attraction/travel/break list for one day, with clock times."""
-    travel_km = travel_km or []
-    raw_items = []
+    """
+    Build the flat [attraction, travel, break, attraction, travel, break, ...] list
+    for one day, then stamp clock times via _recalculate_item_times.
+
+    - travel_minutes[i]  = minutes to travel from attraction i to i+1
+    - break_durations[i] = break duration after gap i, or None if no break
+    - travel_km[i]       = distance for gap i (display only, not used for timing)
+    - gapIndex on travel/break items is the index of the preceding attraction,
+      used by the frontend to identify which gap a travel/break belongs to.
+    """
+    travel_km  = travel_km or []
+    raw_items  = []
     last_index = len(attractions) - 1
+
     for i, attr in enumerate(attractions):
         raw_items.append({"type": "attraction", **attr})
         if i < last_index:
             travel = travel_minutes[i] if i < len(travel_minutes) else 0
             raw_items.append({
-                "type": "travel",
-                "id": f"travel-{attr['id']}",
-                "duration": travel,
-                "gapIndex": i,
+                "type":       "travel",
+                "id":         f"travel-{attr['id']}",
+                "duration":   travel,
+                "gapIndex":   i,
                 "distanceKm": travel_km[i] if i < len(travel_km) else None,
             })
             break_dur = break_durations[i] if i < len(break_durations) else None
             if break_dur is not None:
                 raw_items.append({
-                    "type": "break",
-                    "id": f"break-{attr['id']}",
+                    "type":     "break",
+                    "id":       f"break-{attr['id']}",
                     "duration": break_dur,
                     "gapIndex": i,
                 })
+
     return _recalculate_item_times(raw_items, start_time)
 
 
 def place_to_attraction(place) -> dict:
-    """Serialize a Place ORM row into the attraction dict the planner expects."""
+    """Convert a Place ORM row to the plain dict the planner works with internally."""
     return {
-        "id": place.id,
-        "name_en": place.name_en,
-        "name_pl": place.name_pl,
-        "category": place.category,
-        "description": place.description,
-        "opening_hours": place.opening_hours,
-        "duration": place.duration,
-        "price_range": place.price_range,
-        "image_url": place.image_url,
-        "latitude": place.latitude,
-        "longitude": place.longitude,
+        "id":           place.id,
+        "name_en":      place.name_en,
+        "name_pl":      place.name_pl,
+        "category":     place.category,
+        "description":  place.description,
+        "opening_hours":place.opening_hours,
+        "duration":     place.duration,
+        "price_range":  place.price_range,
+        "image_url":    place.image_url,
+        "latitude":     place.latitude,
+        "longitude":    place.longitude,
     }
 
+
+# ---------------------------------------------------------------------------
+# GENERATION 2 — to be removed when /itinerary/generate is retired
+# ---------------------------------------------------------------------------
 
 def build_daily_itinerary(
     attractions: list[dict],
@@ -215,23 +289,25 @@ def build_daily_itinerary(
     transport_mode: str = "walking",
 ) -> dict:
     """
-    Greedily pack ordered attractions into days under the intensity budget,
-    inserting travel time and (for relaxed) breaks. Returns {"days", "overflow"}.
+    Multi-day greedy packer ported 1:1 from the frontend buildDailyItinerary (utils.js).
+    Respects the order of attractions as received — ordering is the caller's responsibility.
+    Time budget per day comes from intensity config (max_minutes_per_day).
+    Used by POST /itinerary/generate; will be retired when /plan-optimized is live.
     """
-    config = get_intensity_config(intensity)
-    max_minutes = config["max_minutes_per_day"]
+    config          = get_intensity_config(intensity)
+    max_minutes     = config["max_minutes_per_day"]
     max_attractions = config["max_attractions_per_day"]
-    is_relaxed = intensity == "relaxed"
-    speed = get_transport_speed(transport_mode)
+    is_relaxed      = intensity == "relaxed"
+    speed           = get_transport_speed(transport_mode)
 
     days = [
         {
-            "attractions": [],
-            "travelMinutes": [],
-            "travelKm": [],
+            "attractions":    [],
+            "travelMinutes":  [],
+            "travelKm":       [],
             "breakDurations": [],
-            "items": [],
-            "totalMinutes": 0,
+            "items":          [],
+            "totalMinutes":   0,
         }
         for _ in range(num_days)
     ]
@@ -240,13 +316,14 @@ def build_daily_itinerary(
     for attraction in attractions:
         duration = _duration_minutes(attraction.get("duration"))
 
+        # Try to fit into the first day that has room (time + count budget).
         day_index = -1
         for idx, day in enumerate(days):
-            last = day["attractions"][-1] if day["attractions"] else None
-            travel = _haversine_minutes(last, attraction, speed) if last else 0
+            last           = day["attractions"][-1] if day["attractions"] else None
+            travel         = _haversine_minutes(last, attraction, speed) if last else 0
             break_overhead = break_duration_minutes if (is_relaxed and day["attractions"]) else 0
-            fits_time = day["totalMinutes"] + travel + break_overhead + duration <= max_minutes
-            fits_count = max_attractions is None or len(day["attractions"]) < max_attractions
+            fits_time      = day["totalMinutes"] + travel + break_overhead + duration <= max_minutes
+            fits_count     = max_attractions is None or len(day["attractions"]) < max_attractions
             if fits_time and fits_count:
                 day_index = idx
                 break
@@ -254,9 +331,9 @@ def build_daily_itinerary(
         if day_index != -1:
             day = days[day_index]
             if day["attractions"]:
-                last = day["attractions"][-1]
+                last   = day["attractions"][-1]
                 travel = _haversine_minutes(last, attraction, speed)
-                km = _haversine_km(last, attraction)
+                km     = _haversine_km(last, attraction)
                 day["travelMinutes"].append(travel)
                 day["travelKm"].append(_js_round2(km) if km is not None else None)
                 day["totalMinutes"] += travel
@@ -274,6 +351,147 @@ def build_daily_itinerary(
             day["travelMinutes"],
             day["breakDurations"],
             start_time,
+            day["travelKm"],
+        )
+
+    return {"days": days, "overflow": overflow}
+
+
+# ---------------------------------------------------------------------------
+# GENERATION 3 helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_day_settings(
+    day_index: int,
+    global_start: str,
+    global_end: str,
+    global_intensity: str,
+    days_config: list | None,
+) -> dict:
+    """
+    Merge global defaults with the optional per-day override for one day.
+    days_config is a list of plain dicts (serialised from DayConfig by the endpoint);
+    a None entry means "use all globals for this day".
+
+    Returns a dict with: start_time, end_time, intensity, max_minutes, max_attractions.
+    max_minutes = end_time - start_time (intensity no longer controls the time budget).
+    max_attractions comes from the intensity config (its only remaining role).
+    """
+    override = None
+    if days_config and day_index < len(days_config):
+        override = days_config[day_index]
+
+    start_time = (override.get("start_time") or global_start)     if override else global_start
+    end_time   = (override.get("end_time")   or global_end)       if override else global_end
+    intensity  = (override.get("intensity")  or global_intensity) if override else global_intensity
+
+    max_minutes = _time_to_minutes(end_time) - _time_to_minutes(start_time)
+    config      = get_intensity_config(intensity)
+
+    return {
+        "start_time":      start_time,
+        "end_time":        end_time,
+        "intensity":       intensity,
+        "max_minutes":     max_minutes,
+        "max_attractions": config["max_attractions_per_day"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# GENERATION 3 — active, used by POST /itinerary/plan-optimized
+# ---------------------------------------------------------------------------
+
+def build_optimized_itinerary(
+    attractions: list[dict],
+    num_days: int,
+    global_intensity: str = "moderate",
+    global_start_time: str = "09:00",
+    global_end_time: str = "17:00",
+    transport_mode: str = "walking",
+    break_duration_minutes: int = 30,
+    days_config: list | None = None,
+) -> dict:
+    """
+    Greedy packer with per-day time windows and per-day intensity overrides.
+
+    Key differences from build_daily_itinerary (Gen 2):
+    - Time budget per day = end_time - start_time, NOT intensity.max_minutes_per_day.
+      Intensity only controls the attraction count cap for each day.
+    - Each day in the response includes startTime, endTime, intensity fields.
+    - days_config allows overriding any of these per day.
+
+    Steps still to be added (see endpoints/itinerary.py for the full roadmap):
+    - Pinned attractions: pre-assign specific place_ids to specific days before
+      the greedy loop runs (place_ids in pins are removed from the free pool).
+    - Anchor resolution: Stary Rynek default, prev/next day handoff logic.
+    - Route optimisation: nearest-neighbour + 2-opt within each day.
+    """
+    speed    = get_transport_speed(transport_mode)
+    resolved = [
+        _resolve_day_settings(i, global_start_time, global_end_time, global_intensity, days_config)
+        for i in range(num_days)
+    ]
+
+    days = [
+        {
+            "attractions":    [],
+            "travelMinutes":  [],
+            "travelKm":       [],
+            "breakDurations": [],
+            "items":          [],
+            "totalMinutes":   0,
+            "startTime":      r["start_time"],
+            "endTime":        r["end_time"],
+            "intensity":      r["intensity"],
+        }
+        for r in resolved
+    ]
+    overflow = []
+
+    # TODO (pinned attractions step): pre-assign pinned attractions here before
+    # the loop below, so the greedy packer treats them as already placed.
+
+    for attraction in attractions:
+        duration = _duration_minutes(attraction.get("duration"))
+
+        # Try to fit into the first day with room (time + count budget).
+        day_index = -1
+        for idx, day in enumerate(days):
+            r          = resolved[idx]
+            is_relaxed = r["intensity"] == "relaxed"
+            last       = day["attractions"][-1] if day["attractions"] else None
+            travel     = _haversine_minutes(last, attraction, speed) if last else 0
+            break_oh   = break_duration_minutes if (is_relaxed and day["attractions"]) else 0
+            fits_time  = day["totalMinutes"] + travel + break_oh + duration <= r["max_minutes"]
+            fits_count = r["max_attractions"] is None or len(day["attractions"]) < r["max_attractions"]
+            if fits_time and fits_count:
+                day_index = idx
+                break
+
+        if day_index != -1:
+            day        = days[day_index]
+            is_relaxed = resolved[day_index]["intensity"] == "relaxed"
+            if day["attractions"]:
+                last   = day["attractions"][-1]
+                travel = _haversine_minutes(last, attraction, speed)
+                km     = _haversine_km(last, attraction)
+                day["travelMinutes"].append(travel)
+                day["travelKm"].append(_js_round2(km) if km is not None else None)
+                day["totalMinutes"] += travel
+                day["breakDurations"].append(break_duration_minutes if is_relaxed else None)
+                if is_relaxed:
+                    day["totalMinutes"] += break_duration_minutes
+            day["attractions"].append(attraction)
+            day["totalMinutes"] += duration
+        else:
+            overflow.append(attraction)
+
+    for i, day in enumerate(days):
+        day["items"] = _compute_day_items(
+            day["attractions"],
+            day["travelMinutes"],
+            day["breakDurations"],
+            resolved[i]["start_time"],
             day["travelKm"],
         )
 

--- a/travel-guide/backend/app/services/planner_service.py
+++ b/travel-guide/backend/app/services/planner_service.py
@@ -200,15 +200,53 @@ def _haversine_minutes(a: dict | None, b: dict | None, speed_kmh: int = 5) -> in
     return math.ceil(raw / 5) * 5
 
 
-def _recalculate_item_times(items: list[dict], start_time: str) -> list[dict]:
+def _pad_travel(minutes: int) -> int:
+    """
+    Round travel time UP to the nearest 10-minute interval.
+    The gap in the schedule is always a round number so the user has leeway —
+    e.g. 7 min → 10 min, 17 min → 20 min, 25 min → 30 min.
+    Returns 0 for zero-duration legs (same location).
+    The raw travel time is preserved separately on the item as 'actualMinutes'.
+    """
+    if minutes <= 0:
+        return 0
+    return math.ceil(minutes / 10) * 10
+
+
+def _recalculate_item_times(
+    items: list[dict],
+    start_time: str,
+    pin_conflicts: list | None = None,
+) -> list[dict]:
     """
     Walk through a flat list of attraction/travel/break items and assign
     sequential start_at / end_at clock strings to each one.
-    Each item's duration drives the clock forward.
+
+    If an attraction has a 'pinned_time' key the clock jumps forward to that
+    time before scheduling it. If the preceding items already ran past
+    pinned_time, a conflict entry is appended to pin_conflicts (if provided)
+    and the attraction is scheduled at the earliest available moment instead.
     """
     current = _time_to_minutes(start_time)
     result  = []
     for item in items:
+        if item["type"] == "attraction" and item.get("pinned_time"):
+            target = _time_to_minutes(item["pinned_time"])
+            if current > target:
+                if pin_conflicts is not None:
+                    pin_conflicts.append({
+                        "type":     "pin_time_conflict",
+                        "place_id": item.get("id"),
+                        "name":     item.get("name_en") or item.get("name_pl"),
+                        "message": (
+                            f"'{item.get('name_en') or item.get('name_pl')}' is pinned at "
+                            f"{item['pinned_time']} but the schedule reaches that point at "
+                            f"{_minutes_to_time(current)}. Scheduled at earliest available time."
+                        ),
+                    })
+            else:
+                current = target  # jump forward; gap before this attraction is free time
+
         duration = (
             _duration_minutes(item.get("duration"))
             if item["type"] == "attraction"
@@ -221,7 +259,10 @@ def _recalculate_item_times(items: list[dict], start_time: str) -> list[dict]:
     return result
 
 
-def _compute_day_items(attractions, travel_minutes, break_durations, start_time, travel_km=None):
+def _compute_day_items(
+    attractions, travel_minutes, break_durations, start_time,
+    travel_km=None, pin_conflicts: list | None = None,
+):
     """
     Build the flat [attraction, travel, break, attraction, travel, break, ...] list
     for one day, then stamp clock times via _recalculate_item_times.
@@ -231,6 +272,7 @@ def _compute_day_items(attractions, travel_minutes, break_durations, start_time,
     - travel_km[i]       = distance for gap i (display only, not used for timing)
     - gapIndex on travel/break items is the index of the preceding attraction,
       used by the frontend to identify which gap a travel/break belongs to.
+    - pin_conflicts: if provided, any pinned_time conflicts are appended to it.
     """
     travel_km  = travel_km or []
     raw_items  = []
@@ -241,11 +283,12 @@ def _compute_day_items(attractions, travel_minutes, break_durations, start_time,
         if i < last_index:
             travel = travel_minutes[i] if i < len(travel_minutes) else 0
             raw_items.append({
-                "type":       "travel",
-                "id":         f"travel-{attr['id']}",
-                "duration":   travel,
-                "gapIndex":   i,
-                "distanceKm": travel_km[i] if i < len(travel_km) else None,
+                "type":          "travel",
+                "id":            f"travel-{attr['id']}",
+                "duration":      _pad_travel(travel),  # rounded up to nearest 10 — drives the clock
+                "actualMinutes": travel,               # raw travel time shown to the user
+                "gapIndex":      i,
+                "distanceKm":    travel_km[i] if i < len(travel_km) else None,
             })
             break_dur = break_durations[i] if i < len(break_durations) else None
             if break_dur is not None:
@@ -256,7 +299,7 @@ def _compute_day_items(attractions, travel_minutes, break_durations, start_time,
                     "gapIndex": i,
                 })
 
-    return _recalculate_item_times(raw_items, start_time)
+    return _recalculate_item_times(raw_items, start_time, pin_conflicts)
 
 
 def place_to_attraction(place) -> dict:
@@ -675,6 +718,7 @@ def build_optimized_itinerary(
     transport_mode: str = "walking",
     break_duration_minutes: int = 30,
     days_config: list | None = None,
+    pins: list | None = None,
 ) -> dict:
     """
     Greedy packer with per-day time windows and per-day intensity overrides.
@@ -691,7 +735,8 @@ def build_optimized_itinerary(
     - Route optimisation: nearest-neighbour + 2-opt within each day,
       consuming startAnchor/endAnchor already resolved on each day dict.
     """
-    speed = get_transport_speed(transport_mode)
+    speed    = get_transport_speed(transport_mode)
+    warnings: list = []  # collected throughout; returned at the end
 
     # Pre-build pairwise haversine distance matrix (km) for all attractions.
     # Keyed by (id_a, id_b); symmetric so both directions are stored.
@@ -726,10 +771,37 @@ def build_optimized_itinerary(
     ]
     overflow = []
 
-    # TODO (pinned attractions step): pre-assign pinned attractions here before
-    # the loop below, so the greedy packer treats them as already placed.
+    # Pre-assign pinned attractions to their designated days.
+    # They are removed from the free pool so the greedy packer never double-places them.
+    # If a pin specifies a time, it is stored on the attraction dict so
+    # _recalculate_item_times can jump the clock to that time when it reaches it.
+    pinned_ids: set = set()
+    if pins:
+        for pin in pins:
+            day_idx  = pin.get("day", -1)
+            place_id = pin.get("place_id")
+            if day_idx < 0 or day_idx >= num_days:
+                warnings.append({
+                    "type":     "invalid_pin",
+                    "place_id": place_id,
+                    "message":  f"Pin for place {place_id} targets day {day_idx + 1} "
+                                f"which does not exist (trip has {num_days} day(s)).",
+                })
+                continue
+            attr = next((a for a in attractions if a["id"] == place_id), None)
+            if attr is None:
+                continue
+            pinned_attr = dict(attr)
+            if pin.get("time"):
+                pinned_attr["pinned_time"] = pin["time"]
+            days[day_idx]["attractions"].append(pinned_attr)
+            days[day_idx]["totalMinutes"] += _duration_minutes(attr.get("duration"))
+            pinned_ids.add(place_id)
 
-    for attraction in attractions:
+    # Free pool: all attractions not already pinned to a specific day.
+    free_attractions = [a for a in attractions if a["id"] not in pinned_ids]
+
+    for attraction in free_attractions:
         duration = _duration_minutes(attraction.get("duration"))
 
         # Try to fit into the first day with room (time + count budget).
@@ -738,7 +810,7 @@ def build_optimized_itinerary(
             r          = resolved[idx]
             is_relaxed = r["intensity"] == "relaxed"
             last       = day["attractions"][-1] if day["attractions"] else None
-            travel     = _haversine_minutes(last, attraction, speed) if last else 0
+            travel     = _pad_travel(_haversine_minutes(last, attraction, speed)) if last else 0
             break_oh   = break_duration_minutes if (is_relaxed and day["attractions"]) else 0
             fits_time  = day["totalMinutes"] + travel + break_oh + duration <= r["max_minutes"]
             fits_count = r["max_attractions"] is None or len(day["attractions"]) < r["max_attractions"]
@@ -755,7 +827,7 @@ def build_optimized_itinerary(
                 km     = _haversine_km(last, attraction)
                 day["travelMinutes"].append(travel)
                 day["travelKm"].append(_js_round2(km) if km is not None else None)
-                day["totalMinutes"] += travel
+                day["totalMinutes"] += _pad_travel(travel)
                 day["breakDurations"].append(break_duration_minutes if is_relaxed else None)
                 if is_relaxed:
                     day["totalMinutes"] += break_duration_minutes
@@ -794,9 +866,9 @@ def build_optimized_itinerary(
             if j < len(atts) - 1:
                 km     = _km_cached(attr, atts[j + 1], dist_cache)
                 travel = int(math.ceil((km / speed) * 60 / 5) * 5) if km else 0
-                t_mins.append(travel)
+                t_mins.append(travel)      # raw nearest-5 — stored for display
                 t_km.append(_js_round2(km) if km is not None else None)
-                total += travel
+                total += _pad_travel(travel)  # nearest-10 — drives totalMinutes
                 b_durs.append(break_duration_minutes if is_relaxed else None)
                 if is_relaxed:
                     total += break_duration_minutes
@@ -806,6 +878,7 @@ def build_optimized_itinerary(
         day["breakDurations"] = b_durs
         day["totalMinutes"]   = total
 
+    pin_conflicts: list = []
     for i, day in enumerate(days):
         day["items"] = _compute_day_items(
             day["attractions"],
@@ -813,10 +886,10 @@ def build_optimized_itinerary(
             day["breakDurations"],
             resolved[i]["start_time"],
             day["travelKm"],
+            pin_conflicts,
         )
 
-    # Collect warnings after items are built (rest check needs actual end times).
-    warnings = []
+    # Collect remaining warnings after items are built (rest check needs actual end times).
     for i in range(num_days):
         w = _check_intensity_window(i, resolved)
         if w:
@@ -825,4 +898,4 @@ def build_optimized_itinerary(
         if w:
             warnings.append(w)
 
-    return {"days": days, "overflow": overflow, "warnings": warnings}
+    return {"days": days, "overflow": overflow, "warnings": warnings + pin_conflicts}

--- a/travel-guide/backend/app/services/transport_service.py
+++ b/travel-guide/backend/app/services/transport_service.py
@@ -61,6 +61,32 @@ def _call_google(origin_lat, origin_lon, dest_lat, dest_lon, mode_key: str) -> d
         return None
 
 
+def get_single_travel_time(
+    origin_lat: float, origin_lon: float,
+    dest_lat: float, dest_lon: float,
+    mode: str = "walking",
+) -> dict:
+    """
+    Return travel time and distance for a single mode between two coordinates.
+    Used by the finalize endpoint to replace haversine estimates with Google times
+    one leg at a time, for the mode the user actually selected.
+    Falls back to haversine if the Google API is unavailable or returns an error.
+
+    Returns: {"minutes": int, "distance_km": float, "source": "google"|"estimate"}
+    """
+    if mode not in _GOOGLE_MODES:
+        mode = "walking"
+    km     = _haversine_km(origin_lat, origin_lon, dest_lat, dest_lon)
+    google = _call_google(origin_lat, origin_lon, dest_lat, dest_lon, mode)
+    if google:
+        return {**google, "source": "google"}
+    return {
+        "minutes":     _fallback_minutes(km, mode),
+        "distance_km": round(km, 2),
+        "source":      "estimate",
+    }
+
+
 def get_travel_times(origin_lat: float, origin_lon: float, dest_lat: float, dest_lon: float) -> dict:
     """
     Return travel time and distance for all 4 modes between two coordinates.

--- a/travel-guide/backend/scripts/test_planner.py
+++ b/travel-guide/backend/scripts/test_planner.py
@@ -12,6 +12,7 @@ Options:
     --days N               number of days (default 1)
     --intensity KEY        relaxed | moderate | intense (default moderate)
     --start HH:MM          daily start time (default 09:00)
+    --end HH:MM            daily end time (default 21:00)
     --break N              break minutes for relaxed days (default 30)
     --transport MODE       walking | cycling | transit (default walking)
 """
@@ -25,7 +26,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.db.session import SessionLocal
 from app.models.place import Place
-from app.services.planner_service import build_daily_itinerary, place_to_attraction
+from app.services.planner_service import build_itinerary, place_to_attraction
 
 
 def list_places(db):
@@ -53,11 +54,15 @@ def print_plan(plan):
                 print(f"  {window}  📍 {name}  ({item.get('duration')})")
             elif t == "travel":
                 if item["duration"] > 0:
+                    actual = item.get("actualMinutes", item["duration"])
                     dist = f" · {item['distanceKm']} km" if item["distanceKm"] is not None else ""
-                    print(f"  {window}     ↳ travel {item['duration']} min{dist}")
+                    print(f"  {window}     ↳ travel ~{actual} min (gap {item['duration']} min){dist}")
             elif t == "break":
                 print(f"  {window}     ☕ break {item['duration']} min")
 
+    if plan.get("warnings"):
+        for w in plan["warnings"]:
+            print(f"\n⚠ {w.get('message', w)}")
     if plan["overflow"]:
         names = [a.get("name_en") or a.get("name_pl") for a in plan["overflow"]]
         print(f"\n⚠ Overflow (did not fit): {', '.join(names)}")
@@ -71,6 +76,7 @@ def main():
     parser.add_argument("--days", type=int, default=1)
     parser.add_argument("--intensity", type=str, default="moderate")
     parser.add_argument("--start", type=str, default="09:00")
+    parser.add_argument("--end", type=str, default="21:00")
     parser.add_argument("--break", dest="brk", type=int, default=30)
     parser.add_argument("--transport", type=str, default="walking")
     args = parser.parse_args()
@@ -91,14 +97,15 @@ def main():
         attractions = [place_to_attraction(by_id[i]) for i in ids if i in by_id]
 
         print(f"\nPlanning {len(attractions)} attractions over {args.days} day(s)  ·  "
-              f"intensity={args.intensity}  start={args.start}  "
+              f"intensity={args.intensity}  {args.start}–{args.end}  "
               f"transport={args.transport}  break={args.brk}min")
 
-        plan = build_daily_itinerary(
+        plan = build_itinerary(
             attractions,
             num_days=args.days,
-            intensity=args.intensity,
-            start_time=args.start,
+            global_intensity=args.intensity,
+            global_start_time=args.start,
+            global_end_time=args.end,
             break_duration_minutes=args.brk,
             transport_mode=args.transport,
         )

--- a/travel-guide/frontend/src/App.jsx
+++ b/travel-guide/frontend/src/App.jsx
@@ -4,11 +4,11 @@ import "leaflet/dist/leaflet.css";
 import { CATEGORIES } from "./constants";
 import {
   parseDurationToMinutes, formatMinutes,
-  buildDailyItinerary, computeDayItems, computeTravelMinutes, computeTravelKm,
+  computeDayItems, computeTravelMinutes, computeTravelKm,
   getTransportSpeed,
 } from "./utils";
 import { getDayScheduleValidation } from "./itineraryValidation";
-import { fetchPlaces, loadPreferences, savePreferences } from "./services/api";
+import { fetchPlaces, loadPreferences, savePreferences, planItinerary } from "./services/api";
 import AttractionDetailsModal from "./components/AttractionDetailsModal";
 import HomePage from "./pages/HomePage";
 import ResultsPage from "./pages/ResultsPage";
@@ -35,7 +35,9 @@ function App() {
   const [intensity, setIntensity] = useState("moderate");
   const [startTime, setStartTime] = useState("09:00");
   const [transportMode, setTransportMode] = useState("walking");
+  const [endTime, setEndTime] = useState("21:00");
   const [itineraryDays, setItineraryDays] = useState(null);
+  const [isGeneratingItinerary, setIsGeneratingItinerary] = useState(false);
   const [scheduleNotice, setScheduleNotice] = useState("");
 
   const retryLoadAttractions = useCallback(async () => {
@@ -148,16 +150,45 @@ function App() {
     }
   };
 
-  const generateItinerary = () => {
-    setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, intensity, startTime, 30, transportMode));
+  const generateItinerary = async () => {
+    setIsGeneratingItinerary(true);
     setScheduleNotice("");
-    setPage("itinerary");
+    try {
+      const result = await planItinerary({
+        place_ids: selectedAttractions.map((a) => a.id),
+        num_days: numDays,
+        intensity,
+        start_time: startTime,
+        end_time: endTime,
+        transport_mode: transportMode,
+        break_duration_minutes: 30,
+      });
+      setItineraryDays(result);
+      setPage("itinerary");
+    } catch {
+      setScheduleNotice("Could not generate itinerary. Please check that the backend is running.");
+    } finally {
+      setIsGeneratingItinerary(false);
+    }
   };
 
-  const changeIntensity = (newIntensity) => {
+  const changeIntensity = async (newIntensity) => {
     setIntensity(newIntensity);
-    setItineraryDays(buildDailyItinerary(selectedAttractions, numDays, newIntensity, startTime, 30, transportMode));
-    setScheduleNotice("");
+    try {
+      const result = await planItinerary({
+        place_ids: selectedAttractions.map((a) => a.id),
+        num_days: numDays,
+        intensity: newIntensity,
+        start_time: startTime,
+        end_time: endTime,
+        transport_mode: transportMode,
+        break_duration_minutes: 30,
+      });
+      setItineraryDays(result);
+      setScheduleNotice("");
+    } catch {
+      setScheduleNotice("Could not regenerate itinerary. Please check that the backend is running.");
+    }
   };
 
   const buildUpdatedDay = (day, newAttractions, newBreakDurations) => {
@@ -325,6 +356,7 @@ function App() {
           onShowAttractionDetails={setSelectedAttractionDetails}
           onBack={() => setPage("home")}
           onGenerateItinerary={generateItinerary}
+          isGeneratingItinerary={isGeneratingItinerary}
         />
       )}
 

--- a/travel-guide/frontend/src/App.jsx
+++ b/travel-guide/frontend/src/App.jsx
@@ -162,6 +162,7 @@ function App() {
         end_time: endTime,
         transport_mode: transportMode,
         break_duration_minutes: 30,
+        selected_categories: selectedCategories,
       });
       setItineraryDays(result);
       setPage("itinerary");
@@ -183,6 +184,7 @@ function App() {
         end_time: endTime,
         transport_mode: transportMode,
         break_duration_minutes: 30,
+        selected_categories: selectedCategories,
       });
       setItineraryDays(result);
       setScheduleNotice("");

--- a/travel-guide/frontend/src/pages/ItineraryPage.jsx
+++ b/travel-guide/frontend/src/pages/ItineraryPage.jsx
@@ -132,7 +132,7 @@ export default function ItineraryPage({
                           {item.duration > 0 && (
                             <>
                               <span className="travel-icon">{icon}</span>
-                              <span className="travel-label">{item.duration} min {modeLabel}</span>
+                              <span className="travel-label">{item.actualMinutes ?? item.duration} min {modeLabel}</span>
                               {item.distanceKm !== null && item.distanceKm !== undefined && (
                                 <span className="travel-distance">{item.distanceKm} km</span>
                               )}

--- a/travel-guide/frontend/src/pages/ResultsPage.jsx
+++ b/travel-guide/frontend/src/pages/ResultsPage.jsx
@@ -12,7 +12,7 @@ export default function ResultsPage({
   attractions, selectedAttractions, selectedCategories, allCategoriesSelected,
   isLoadingAttractions, attractionsError,
   onRetryAttractions, onToggleAttraction, onToggleCategory, onToggleAllCategories,
-  onShowAttractionDetails, onBack, onGenerateItinerary,
+  onShowAttractionDetails, onBack, onGenerateItinerary, isGeneratingItinerary,
 }) {
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -35,10 +35,10 @@ export default function ResultsPage({
         </div>
         <button
           className="primary"
-          disabled={selectedAttractions.length === 0}
+          disabled={selectedAttractions.length === 0 || isGeneratingItinerary}
           onClick={onGenerateItinerary}
         >
-          Generate Itinerary
+          {isGeneratingItinerary ? "Planning…" : "Generate Itinerary"}
         </button>
       </div>
 

--- a/travel-guide/frontend/src/services/api.js
+++ b/travel-guide/frontend/src/services/api.js
@@ -57,6 +57,7 @@ export function planItinerary({
   end_time = "21:00",
   transport_mode = "walking",
   break_duration_minutes = 30,
+  selected_categories = [],
 }) {
   return request("/itinerary/plan", {
     method: "POST",
@@ -68,6 +69,7 @@ export function planItinerary({
       end_time,
       transport_mode,
       break_duration_minutes,
+      selected_categories,
     }),
   });
 }

--- a/travel-guide/frontend/src/services/api.js
+++ b/travel-guide/frontend/src/services/api.js
@@ -49,6 +49,29 @@ export function fetchPlaces() {
   return request("/places");
 }
 
+export function planItinerary({
+  place_ids,
+  num_days = 1,
+  intensity = "moderate",
+  start_time = "09:00",
+  end_time = "21:00",
+  transport_mode = "walking",
+  break_duration_minutes = 30,
+}) {
+  return request("/itinerary/plan", {
+    method: "POST",
+    body: JSON.stringify({
+      place_ids,
+      num_days,
+      intensity,
+      start_time,
+      end_time,
+      transport_mode,
+      break_duration_minutes,
+    }),
+  });
+}
+
 export function fetchCategories() {
   return request("/categories");
 }

--- a/travel-guide/frontend/src/utils.js
+++ b/travel-guide/frontend/src/utils.js
@@ -1,4 +1,4 @@
-import { INTENSITY_OPTIONS, TRANSPORT_OPTIONS } from "./constants";
+import { TRANSPORT_OPTIONS } from "./constants";
 import L from "leaflet";
 
 export function parseDurationToMinutes(duration) {
@@ -82,7 +82,14 @@ export function computeTravelKm(attractions) {
   });
 }
 
+function padTravel(minutes) {
+  if (minutes <= 0) return 0;
+  return Math.ceil(minutes / 10) * 10;
+}
+
 // Builds the flat items list for one day, inserting travel and break rows.
+// Travel item 'duration' is rounded up to the nearest 10 min (schedule leeway).
+// The raw travel time is preserved as 'actualMinutes' for display.
 export function computeDayItems(attractions, travelMinutes, breakDurations, startTime, travelKm = []) {
   const rawItems = [];
   attractions.forEach((attr, i) => {
@@ -92,7 +99,8 @@ export function computeDayItems(attractions, travelMinutes, breakDurations, star
       rawItems.push({
         type: "travel",
         id: `travel-${attr.id}`,
-        duration: travel,
+        duration: padTravel(travel),
+        actualMinutes: travel,
         gapIndex: i,
         distanceKm: travelKm[i] ?? null,
       });
@@ -107,69 +115,6 @@ export function computeDayItems(attractions, travelMinutes, breakDurations, star
 
 export function getTransportSpeed(transportMode) {
   return TRANSPORT_OPTIONS.find((o) => o.key === transportMode)?.speedKmh ?? 5;
-}
-
-export function buildDailyItinerary(
-  attractions,
-  numDays,
-  intensityKey,
-  startTime = "09:00",
-  breakDurationMinutes = 30,
-  transportMode = "walking"
-) {
-  const config = INTENSITY_OPTIONS.find((o) => o.key === intensityKey);
-  const maxMinPerDay = config.maxMinutesPerDay;
-  const isRelaxed = intensityKey === "relaxed";
-  const speedKmh = getTransportSpeed(transportMode);
-
-  const days = Array.from({ length: numDays }, () => ({
-    attractions: [],
-    travelMinutes: [],
-    travelKm: [],
-    breakDurations: [],
-    items: [],
-    totalMinutes: 0,
-  }));
-  const overflow = [];
-
-  for (const attraction of attractions) {
-    const duration = parseDurationToMinutes(attraction.duration);
-
-    const dayIndex = days.findIndex((day) => {
-      const last = day.attractions[day.attractions.length - 1];
-      const travel = last ? haversineMinutes(last, attraction, speedKmh) : 0;
-      const breakOverhead = isRelaxed && day.attractions.length > 0 ? breakDurationMinutes : 0;
-      return (
-        day.totalMinutes + travel + breakOverhead + duration <= maxMinPerDay &&
-        (config.maxAttractionsPerDay === null || day.attractions.length < config.maxAttractionsPerDay)
-      );
-    });
-
-    if (dayIndex !== -1) {
-      const day = days[dayIndex];
-      if (day.attractions.length > 0) {
-        const last = day.attractions[day.attractions.length - 1];
-        const travel = haversineMinutes(last, attraction, speedKmh);
-        const km = haversineKm(last, attraction);
-        day.travelMinutes.push(travel);
-        day.travelKm.push(km !== null ? Math.round(km * 100) / 100 : null);
-        day.totalMinutes += travel;
-        day.breakDurations.push(isRelaxed ? breakDurationMinutes : null);
-        if (isRelaxed) day.totalMinutes += breakDurationMinutes;
-      }
-      day.attractions.push(attraction);
-      day.totalMinutes += duration;
-    } else {
-      overflow.push(attraction);
-    }
-  }
-
-  const daysWithItems = days.map((day) => ({
-    ...day,
-    items: computeDayItems(day.attractions, day.travelMinutes, day.breakDurations, startTime, day.travelKm),
-  }));
-
-  return { days: daysWithItems, overflow };
 }
 
 export function createMarkerIcon(color, label) {


### PR DESCRIPTION
## Overview

Moves itinerary generation entirely to the backend and replaces the two legacy endpoints (`/plan`, `/generate`) with a single `POST /itinerary/plan`. The client-side `buildDailyItinerary` function in the frontend is removed.

## What's new

**Route optimisation** — attractions are reordered each day using a nearest-neighbour heuristic followed by 2-opt improvement. A per-request haversine distance cache avoids redundant computation in the inner loop. In testing this reduced total walking time by ~33% compared to click order.

**Per-day time windows** — each day has a `start_time` and `end_time` (global defaults: 09:00–21:00). The time budget is `end_time − start_time`; intensity now only controls the attraction count cap, not the time cap.

**Smart day anchors** — the route optimiser knows where each day starts and ends:
- Day 1 starts at Stary Rynek by default
- Later days start at the last attraction of the previous day (or its explicit end anchor)
- Last day ends back at Stary Rynek by default
- Explicit GPS coordinates can override any anchor via `days_config`

**Per-day configuration** — `days_config` accepts an array of overrides (start/end time, intensity, anchors) per day. Any field left null falls back to the global default.

**Pinned attractions** — `pins` locks a `place_id` to a specific day and optional exact time. Pins are pre-assigned before the greedy packer runs, so a pinned attraction always appears on the requested day regardless of the time budget. Time conflicts are returned as warnings, not errors.

**Travel gap rounding** — schedule gaps are rounded up to the nearest 10 minutes (e.g. 17 min walk → 20 min gap) so users have built-in leeway. The real travel time and distance are preserved on each item for display (`actualMinutes`, `distanceKm`).

**Validation warnings** — the response includes a `warnings` array flagging: intensity vs time window mismatches, fewer than 10 hours rest between consecutive days, and pin time conflicts.

**Google finalization** — `POST /itinerary/finalize` accepts a confirmed ordering and swaps the haversine estimates with real Google Distance Matrix times. Falls back to haversine if the API key is unavailable.

**Frontend wired** — the React app now calls `POST /itinerary/plan` on "Generate Itinerary" and on intensity changes. The button shows "Planning…" and is disabled during the request. Travel items display the real travel time, not the padded gap.

## Breaking changes

- `POST /itinerary/plan` (Sprint 1) and `POST /itinerary/generate` (Sprint 2) are removed
- Frontend no longer performs any scheduling client-side

## Notes for reviewers

- `computeDayItems` in `utils.js` is kept for client-side reordering (manual drag/remove after generation); it now also pads travel gaps for consistency with the backend
- The `/finalize` endpoint is implemented but not yet called from the frontend — a follow-up task for the frontend team
- `end_time` state is added to `App.jsx` (default `"21:00"`) but not yet exposed in the UI preferences — also a frontend follow-up