### PR TITLE
Improve itinerary day controls

### DIFF
--- a/travel-guide/frontend/src/App.jsx
+++ b/travel-guide/frontend/src/App.jsx
@@ -246,6 +246,20 @@ function App() {
     };
   };
 
+  const getBreakDurationsAfterAttractionRemoval = (day, attractionIndex) => {
+    if (day.attractions.length <= 1) return [];
+
+    const newBreakDurations = [...day.breakDurations];
+    if (attractionIndex === 0) {
+      newBreakDurations.splice(0, 1);
+    } else if (attractionIndex === day.attractions.length - 1) {
+      newBreakDurations.splice(attractionIndex - 1, 1);
+    } else {
+      newBreakDurations.splice(attractionIndex - 1, 2, null);
+    }
+    return newBreakDurations;
+  };
+
   const applyDayUpdate = (dayIndex, updatedDay, actionLabel) => {
     const validation = getDayScheduleValidation(updatedDay, intensity);
     if (!validation.isValid) {
@@ -267,6 +281,44 @@ function App() {
     const day = itineraryDays?.days[dayIndex];
     if (!day) return;
 
+    if (dir === "prev-day" || dir === "next-day") {
+      const targetDayIndex = dir === "prev-day" ? dayIndex - 1 : dayIndex + 1;
+      const targetDay = itineraryDays?.days[targetDayIndex];
+      const attraction = day.attractions[attractionIndex];
+      if (!targetDay || !attraction) return;
+
+      const sourceAttractions = day.attractions.filter((_, index) => index !== attractionIndex);
+      const sourceBreakDurations = getBreakDurationsAfterAttractionRemoval(day, attractionIndex);
+      const targetAttractions = [...targetDay.attractions, attraction];
+      const targetBreakDurations = [...targetDay.breakDurations];
+      if (targetDay.attractions.length > 0) targetBreakDurations.push(null);
+
+      const updatedSourceDay = buildUpdatedDay(day, sourceAttractions, sourceBreakDurations);
+      const updatedTargetDay = buildUpdatedDay(targetDay, targetAttractions, targetBreakDurations);
+      const sourceValidation = getDayScheduleValidation(updatedSourceDay, intensity);
+      const targetValidation = getDayScheduleValidation(updatedTargetDay, intensity);
+
+      if (!sourceValidation.isValid || !targetValidation.isValid) {
+        const message = [...sourceValidation.blockers, ...targetValidation.blockers][0];
+        setScheduleNotice(`Move to day ${targetDayIndex + 1} was not applied: ${message}`);
+        return;
+      }
+
+      setScheduleNotice("");
+      setItineraryDays((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          days: prev.days.map((currentDay, index) => {
+            if (index === dayIndex) return updatedSourceDay;
+            if (index === targetDayIndex) return updatedTargetDay;
+            return currentDay;
+          }),
+        };
+      });
+      return;
+    }
+
     const targetIndex = dir === "up" ? attractionIndex - 1 : attractionIndex + 1;
     if (targetIndex < 0 || targetIndex >= day.attractions.length) return;
 
@@ -286,14 +338,7 @@ function App() {
         const attrIndex = day.attractions.findIndex((a) => a.id === attractionId);
         if (attrIndex === -1) return day;
         const newAttractions = day.attractions.filter((a) => a.id !== attractionId);
-        const newBreakDurations = [...day.breakDurations];
-        if (attrIndex === 0) {
-          newBreakDurations.splice(0, 1);
-        } else if (attrIndex === day.attractions.length - 1) {
-          newBreakDurations.splice(attrIndex - 1, 1);
-        } else {
-          newBreakDurations.splice(attrIndex - 1, 2, null);
-        }
+        const newBreakDurations = getBreakDurationsAfterAttractionRemoval(day, attrIndex);
         const speed = getTransportSpeed(transportMode);
         const newTravelMinutes = computeTravelMinutes(newAttractions, speed);
         const newTravelKm = computeTravelKm(newAttractions);

--- a/travel-guide/frontend/src/index.css
+++ b/travel-guide/frontend/src/index.css
@@ -393,6 +393,14 @@ h1 {
   cursor: not-allowed;
 }
 
+.day-move-btn {
+  width: 34px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
 .remove-btn {
   width: 28px;
   height: 28px;
@@ -705,6 +713,7 @@ h1 {
 .day-block {
   margin-bottom: 32px;
   border: 1px solid #ddd;
+  border-top: 4px solid var(--day-color, #ddd);
   border-radius: 18px;
   overflow: hidden;
 }
@@ -716,11 +725,24 @@ h1 {
   padding: 20px 24px;
   background: #f7f7f8;
   border-bottom: 1px solid #ddd;
+  box-shadow: inset 6px 0 0 var(--day-color, #ddd);
 }
 
 .day-header h2 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   margin: 0;
   font-size: 20px;
+}
+
+.day-color-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--day-color, #ddd);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.9);
+  flex-shrink: 0;
 }
 
 .day-date {

--- a/travel-guide/frontend/src/pages/ItineraryPage.jsx
+++ b/travel-guide/frontend/src/pages/ItineraryPage.jsx
@@ -1,4 +1,4 @@
-import { INTENSITY_OPTIONS, TRANSPORT_OPTIONS } from "../constants";
+import { DAY_COLORS, INTENSITY_OPTIONS, TRANSPORT_OPTIONS } from "../constants";
 import { getItineraryScheduleValidation } from "../itineraryValidation";
 import { formatMinutes, formatDayDate } from "../utils";
 import ItineraryMap from "../components/ItineraryMap";
@@ -85,11 +85,13 @@ export default function ItineraryPage({
       {days.map((day, dayIndex) => {
         let attrCounter = 0;
         const dayValidation = scheduleValidation.dayValidations[dayIndex];
+        const dayColor = DAY_COLORS[dayIndex % DAY_COLORS.length];
 
         return (
-          <div key={dayIndex} className="day-block">
+          <div key={dayIndex} className="day-block" style={{ "--day-color": dayColor }}>
             <div className="day-header">
               <h2>
+                <span className="day-color-dot" aria-hidden="true" />
                 Day {dayIndex + 1}
                 {arrivalDate && (
                   <span className="day-date"> — {formatDayDate(arrivalDate, dayIndex)}</span>
@@ -228,6 +230,12 @@ export default function ItineraryPage({
                         )}
                         <div className="reorder-btns">
                           <button
+                            className="reorder-btn day-move-btn"
+                            onClick={() => onMoveAttraction(dayIndex, currentAttrIndex, "prev-day")}
+                            disabled={dayIndex === 0}
+                            title="Move to previous day"
+                          >D-</button>
+                          <button
                             className="reorder-btn"
                             onClick={() => onMoveAttraction(dayIndex, currentAttrIndex, "up")}
                             disabled={isFirstAttr}
@@ -239,6 +247,12 @@ export default function ItineraryPage({
                             disabled={isLastAttr}
                             title="Move down"
                           >↓</button>
+                          <button
+                            className="reorder-btn day-move-btn"
+                            onClick={() => onMoveAttraction(dayIndex, currentAttrIndex, "next-day")}
+                            disabled={dayIndex === days.length - 1}
+                            title="Move to next day"
+                          >D+</button>
                         </div>
                         <button
                           className="remove-btn"


### PR DESCRIPTION
## Summary
- Match itinerary day headers with the same colors used for each day on the map.
- Add controls to move attractions between days in the generated itinerary.
- Recalculate travel slots, break slots, item times, total day duration, and schedule validation after moving an attraction to another day.
- Keep the existing same-day reorder controls working.

## Checks
- `npm run lint`
- `npm run build`
- Playwright smoke test with mocked backend data:
  - generated a 2-day itinerary
  - confirmed the day header color matches the map color
  - moved an attraction from Day 1 to Day 2 successfully

## Notes
- The new `D-` button moves an attraction to the previous day.
- The new `D+` button moves an attraction to the next day.
- Moves are blocked if the resulting schedule would become invalid.